### PR TITLE
Added code to handle unsuccessful http response codes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven'
 
-version = '0.6'
+version = '0.7'
 group = 'com.orbitz.consul'
 
 repositories {


### PR DESCRIPTION
When passing in the wrong dc parameter, consul throws a 500 error.  This change handles unsuccessful responses.