### PR TITLE
Preventing intermittent test failure

### DIFF
--- a/src/test/java/com/orbitz/consul/AgentTests.java
+++ b/src/test/java/com/orbitz/consul/AgentTests.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class AgentTests {
 
@@ -47,14 +48,14 @@ public class AgentTests {
     }
 
     @Test
-    public void shouldDeregister() throws UnknownHostException {
+    public void shouldDeregister() throws UnknownHostException, InterruptedException {
         Consul client = Consul.newClient();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
         client.agentClient().register(8080, 10000L, serviceName, serviceId);
         client.agentClient().deregister();
-
+	Thread.sleep(1000L);
         boolean found = false;
 
         for(ServiceHealth health : client.healthClient().getAllNodes(serviceName).getResponse()) {


### PR DESCRIPTION
This one's hard to reproduce. I think I was victim to a timing/stale cache issue with the consul agent itself. It appears that recently deregistered services are still available via the /health/ api. I know that there's not much motive for merging, but if it helps, none of my subsequent development experienced intermittent failures after adding this in.