### PR TITLE
Enabling tests to pass on machines with multiple network adapters.

### DIFF
--- a/src/test/java/com/orbitz/consul/StatusClientTests.java
+++ b/src/test/java/com/orbitz/consul/StatusClientTests.java
@@ -1,31 +1,84 @@
 package com.orbitz.consul;
 
+import java.net.Inet4Address;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class StatusClientTests {
 
-    private static String ip;
+    private static Set<InetAddress> ips = new HashSet<>();
 
     @BeforeClass
-    public static void getIp() throws UnknownHostException {
-        ip = String.format("%s:8300", InetAddress.getLocalHost().getHostAddress());
+    public static void getIps() throws RuntimeException {
+	try {
+	    InetAddress[] externalIps = InetAddress.getAllByName(InetAddress.getLocalHost().getCanonicalHostName());
+	    ips.addAll(Arrays.asList(externalIps));
+	} catch (UnknownHostException ex) {
+	    Logger.getLogger(StatusClientTests.class.getName()).log(Level.WARNING, "Could not determine fully qualified host name. Continuing.", ex);
+	}
+	Enumeration<NetworkInterface> netInts;
+	try {
+	    netInts = NetworkInterface.getNetworkInterfaces();
+	    for(NetworkInterface netInt : Collections.list(netInts)){
+		for(InetAddress inetAddress : Collections.list(netInt.getInetAddresses())){
+		    ips.add(inetAddress);
+		}
+	    }
+	} catch (SocketException ex) {
+	    Logger.getLogger(StatusClientTests.class.getName()).log(Level.WARNING, "Could not access local network adapters. Continuing", ex);
+	}
+	if(ips.isEmpty()){
+	    throw new RuntimeException("Unable to discover any local IP addresses");
+	}
+    }
+
+    public boolean isLocalIp(String ipAddress) throws UnknownHostException{
+	InetAddress ip = InetAddress.getByName(ipAddress);
+	return ips.contains(ip);
+    }
+    public static final String IP_PORT_DELIM = ":";
+    public static final String CONSUL_PORT = "8300";
+    public String getIp(String ipAndPort){
+	return ipAndPort.substring(0, ipAndPort.indexOf(IP_PORT_DELIM));
+    }
+    public String getPort(String ipAndPort){
+	return ipAndPort.substring(ipAndPort.indexOf(IP_PORT_DELIM)+1);
+    }
+    public void assertLocalIpAndCorrectPort(String ipAndPort) throws UnknownHostException{
+	String ip = getIp(ipAndPort);
+	String port = getPort(ipAndPort);
+	assertTrue(isLocalIp(ip));
+	assertEquals(CONSUL_PORT, port);
+    }
+    
+    @Test
+    public void shouldGetLeader() throws UnknownHostException {
+	String ipAndPort = Consul.newClient().statusClient().getLeader();
+	assertLocalIpAndCorrectPort(ipAndPort);
+        
     }
 
     @Test
-    public void shouldGetLeader() {
-        assertEquals(ip, Consul.newClient().statusClient().getLeader());
-    }
-
-    @Test
-    public void shouldGetPeers() {
-        assertEquals(Arrays.asList(new String[] { ip }),
-                Consul.newClient().statusClient().getPeers());
+    public void shouldGetPeers() throws UnknownHostException {
+        List<String> peers = Consul.newClient().statusClient().getPeers();
+	for(String ipAndPort : peers){
+	    	assertLocalIpAndCorrectPort(ipAndPort);
+	}
     }
 }


### PR DESCRIPTION
This adds all of the possible local ip addresses that developer's machine listens on so that it is easy for developers to test the software going forward.

Like an increasing number of developers, I run multiple network adapters on my development vm and I change their configuration frequently depending on the real/virtual machines I have to interface with for varying projects. In fact, during my recent work on this plugin I changed my configuration twice, so at multiple points the StatusClient tests wouldn't pass. This is the most robust solution I came up with that endured subsequent reproductions of the previously breaking network adapter configuration changes.