### PR TITLE
Less state agent client

### DIFF
--- a/src/main/java/com/orbitz/consul/AgentClient.java
+++ b/src/main/java/com/orbitz/consul/AgentClient.java
@@ -226,6 +226,20 @@ public class AgentClient {
     }
 
     /**
+     * De-registers a Health Check with the Agent
+     * 
+     * @param checkId the id of the Check to deregister
+     */
+    public void deregisterCheck(String checkId){
+	Response response = webTarget.path("check").path("deregister").path(checkId)
+		.request().get();
+
+	if (response.getStatus() != Response.Status.OK.getStatusCode()) {
+	    throw new ConsulException(response.readEntity(String.class));
+	}
+    }
+    
+    /**
      * Retrieves the Agent's configuration and member information.
      *
      * GET /v1/agent/self

--- a/src/main/java/com/orbitz/consul/AgentClient.java
+++ b/src/main/java/com/orbitz/consul/AgentClient.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 /**
  * HTTP Client for /v1/agent/ endpoints.
+ * @see http://www.consul.io/docs/agent/http.html#agent
  */
 public class AgentClient {
     
@@ -319,49 +320,59 @@ public class AgentClient {
                 throw new NotRegisteredException();
             }
     }
-
     /**
-     * Checks in with Consul for the default Check.
-     *
-     * @param state The current state of the Check.
-     * @param note Any note to associate with the Check.
+     * Prepends the default TTL prefix to the serviceId to produce a check id,
+     * then delegates to check(String checkId, State state, String note)
+     * This method only works with TTL checks that have not been given a custom
+     * name.
+     * 
+     * @param serviceId
+     * @param state
+     * @param note
+     * @throws NotRegisteredException 
      */
-    public void check(State state, String note) throws NotRegisteredException {
-        check(null, state, note);
+    public void checkTtl(String serviceId, State state, String note) throws NotRegisteredException{
+	check("service:"+serviceId, state, note);
+    }
+    /**
+     * Sets a TTL check to "passing" state
+     */
+    public void pass(String checkId) throws NotRegisteredException {
+        checkTtl(checkId, State.PASS, null);
     }
 
     /**
-     * Checks in with Consul for the default Check and "pass" state.
+     * Sets a TTL check to "passing" state with a note
      */
-    public void pass() throws NotRegisteredException {
-        check(null, State.PASS, null);
+    public void pass(String checkId, String note) throws NotRegisteredException {
+        checkTtl(checkId, State.PASS, note);
+    }
+    
+    /**
+     * Sets a TTL check to "warning" state.
+     */
+    public void warn(String checkId) throws NotRegisteredException {
+        checkTtl(checkId, State.WARN, null);
     }
 
     /**
-     * Checks in with Consul for the default Check and "warn" state.
+     * Sets a TTL check to "warning" state with a note.
      */
-    public void warn() throws NotRegisteredException {
-        check(State.WARN, null);
+    public void warn(String checkId, String note) throws NotRegisteredException {
+        checkTtl(checkId, State.WARN, note);
     }
 
     /**
-     * Checks in with Consul for the default Check and "warn" state.
+     * Sets a TTL check to "critical" state.
      */
-    public void warn(String note) throws NotRegisteredException {
-        check(State.WARN, note);
+    public void fail(String checkId) throws NotRegisteredException {
+        checkTtl(checkId, State.FAIL, null);
     }
 
     /**
-     * Checks in with Consul for the default Check and "fail" state.
+     * Sets a TTL check to "critical" state with a note.
      */
-    public void fail() throws NotRegisteredException {
-        check(State.FAIL, null);
-    }
-
-    /**
-     * Checks in with Consul for the default Check and "fail" state.
-     */
-    public void fail(String note) throws NotRegisteredException {
-        check(State.FAIL, note);
+    public void fail(String checkId, String note) throws NotRegisteredException {
+        checkTtl(checkId, State.FAIL, note);
     }
 }

--- a/src/test/java/com/orbitz/consul/AgentTests.java
+++ b/src/test/java/com/orbitz/consul/AgentTests.java
@@ -54,7 +54,7 @@ public class AgentTests {
         String serviceId = UUID.randomUUID().toString();
 
         client.agentClient().register(8080, 10000L, serviceName, serviceId);
-        client.agentClient().deregister();
+        client.agentClient().deregister(serviceId);
 	Thread.sleep(1000L);
         boolean found = false;
 
@@ -109,7 +109,7 @@ public class AgentTests {
         String note = UUID.randomUUID().toString();
 
         client.agentClient().register(8080, 20L, serviceName, serviceId);
-        client.agentClient().warn(note);
+        client.agentClient().warn(serviceId, note);
 
         verifyState("warning", client, serviceId, serviceName, note);
     }
@@ -122,7 +122,7 @@ public class AgentTests {
         String note = UUID.randomUUID().toString();
 
         client.agentClient().register(8080, 20L, serviceName, serviceId);
-        client.agentClient().fail(note);
+        client.agentClient().fail(serviceId, note);
 
         verifyState("critical", client, serviceId, serviceName, note);
     }

--- a/src/test/java/com/orbitz/consul/AgentTests.java
+++ b/src/test/java/com/orbitz/consul/AgentTests.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class AgentTests {
 
@@ -47,14 +48,14 @@ public class AgentTests {
     }
 
     @Test
-    public void shouldDeregister() throws UnknownHostException {
+    public void shouldDeregister() throws UnknownHostException, InterruptedException {
         Consul client = Consul.newClient();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
         client.agentClient().register(8080, 10000L, serviceName, serviceId);
         client.agentClient().deregister();
-
+	Thread.sleep(1000L);
         boolean found = false;
 
         for(ServiceHealth health : client.healthClient().getAllNodes(serviceName).getResponse()) {

--- a/src/test/java/com/orbitz/consul/HealthTests.java
+++ b/src/test/java/com/orbitz/consul/HealthTests.java
@@ -16,7 +16,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class HealthTests {
-
     @Test
     public void shouldFetchPassingNode() throws UnknownHostException, NotRegisteredException {
         Consul client = Consul.newClient();
@@ -24,13 +23,13 @@ public class HealthTests {
         String serviceId = UUID.randomUUID().toString();
 
         client.agentClient().register(8080, 20L, serviceName, serviceId);
-        client.agentClient().pass();
+        client.agentClient().pass(serviceId);
 
         Consul client2 = Consul.newClient();
         String serviceId2 = UUID.randomUUID().toString();
 
         client2.agentClient().register(8080, 20L, serviceName, serviceId2);
-        client2.agentClient().fail();
+        client2.agentClient().fail(serviceId2);
 
         boolean found = false;
         ConsulResponse<List<ServiceHealth>> response = client2.healthClient().getHealthyNodes(serviceName);
@@ -44,7 +43,7 @@ public class HealthTests {
         String serviceId = UUID.randomUUID().toString();
 
         client.agentClient().register(8080, 20L, serviceName, serviceId);
-        client.agentClient().pass();
+        client.agentClient().pass(serviceId);
 
         boolean found = false;
         ConsulResponse<List<ServiceHealth>> response = client.healthClient().getAllNodes(serviceName);
@@ -58,7 +57,7 @@ public class HealthTests {
         String serviceId = UUID.randomUUID().toString();
 
         client.agentClient().register(8080, 20L, serviceName, serviceId);
-        client.agentClient().pass();
+        client.agentClient().pass(serviceId);
 
         boolean found = false;
         ConsulResponse<List<ServiceHealth>> response = client.healthClient().getAllNodes(serviceName,
@@ -73,7 +72,7 @@ public class HealthTests {
         String serviceId = UUID.randomUUID().toString();
 
         client.agentClient().register(8080, 20L, serviceName, serviceId);
-        client.agentClient().pass();
+        client.agentClient().pass(serviceId);
 
         boolean found = false;
         ConsulResponse<List<ServiceHealth>> response = client.healthClient().getAllNodes(serviceName,
@@ -89,7 +88,7 @@ public class HealthTests {
         String serviceId = UUID.randomUUID().toString();
 
         client.agentClient().register(8080, 20L, serviceName, serviceId);
-        client.agentClient().warn();
+        client.agentClient().warn(serviceId);
 
         boolean found = false;
         ConsulResponse<List<HealthCheck>> response = client.healthClient().getChecksByState(State.WARN);


### PR DESCRIPTION
I've removed the management of state from the AgentClient in the interest of making it more broadly useful.

These changes enable you to interact with multiple Consul Services and Checks using one AgentClient instance. Currently this Java API does not permit you to interact with multiple Consul Services and Checks via the same agent; rather you would need to construct a new AgentClient for every host-Service pair or for every host-Check pair that you wanted to interact with.

These changes also enable you to interact with checks and services if you do not have a reference to the AgentClient that registered them. For example, if the HealthClient gives you a list of Consul services failing their health checks and you want to deregister each of those services, the current Java API would require that you create an AgentClient for each of the failing services, re-register each service, and then deregister each one. The proposed changes permit you to create a single AgentClient and deregister each of the failing services. Currently the Java API cannot deregister a specific check. These changes add the ability to do so.
