### PR TITLE
Avoid NPE in KeyValueClient#getSession

### DIFF
--- a/src/main/java/com/orbitz/consul/KeyValueClient.java
+++ b/src/main/java/com/orbitz/consul/KeyValueClient.java
@@ -267,9 +267,9 @@ public class KeyValueClient {
      * {@link Optional#absent()}
      */
     public Optional<String> getSession(String key) {
-        Optional<Value> session = getValue(key);
+        Optional<Value> value = getValue(key);
 
-        return session.isPresent() ? Optional.of(session.get().getSession()) : Optional.<String>absent();
+        return value.isPresent() ? Optional.fromNullable(value.get().getSession()) : Optional.<String>absent();
     }
 
 

--- a/src/test/java/com/orbitz/consul/KeyValueTests.java
+++ b/src/test/java/com/orbitz/consul/KeyValueTests.java
@@ -110,14 +110,19 @@ public class KeyValueTests {
         Consul client = Consul.newClient();
         KeyValueClient keyValueClient = client.keyValueClient();
         SessionClient sessionClient = client.sessionClient();
-        String key = UUID.randomUUID().toString();
 
-        final String value = "{\"Name\":\"myservice\"}";
-        String session = sessionClient.createSession(value).get();
+        String key = UUID.randomUUID().toString();
+        String value = UUID.randomUUID().toString();
+        keyValueClient.putValue(key, value);
+
+        assertEquals(false, keyValueClient.getSession(key).isPresent());
+
+        final String sessionValue = "{\"Name\":\"myservice\"}";
+        String session = sessionClient.createSession(sessionValue).get();
 
         System.out.println("SessionInfo: " + session);
-        assertTrue(keyValueClient.acquireLock(key, value, session));
-        assertFalse(keyValueClient.acquireLock(key, value, session));
+        assertTrue(keyValueClient.acquireLock(key, sessionValue, session));
+        assertFalse(keyValueClient.acquireLock(key, sessionValue, session));
         assertEquals(session, keyValueClient.getSession(key).get());
     }
 


### PR DESCRIPTION
Return absent Optional rather than throwing a NullPointerException when KeyValueClient#getSession is called for a key that exists but is not associated with a session.