### PR TITLE
update libraries, and make cxf optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ repositories {
 
 dependencies {
     compile 'com.orbitz.consul:consul-client:0.8.4'
+    // include your preferred javax.ws.rs-api implementation, for example:
+    compile 'org.apache.cxf:cxf-rt-rs-client:3.0.3'
+    compile 'org.apache.cxf:cxf-rt-transports-http-hc:3.0.3'
 }
 ```
 
@@ -35,6 +38,7 @@ dependencies {
         <artifactId>consul-client</artifactId>
         <version>0.8.4</version>
     </dependency>
+    <!-- include your preferred javax.ws.rs-api implementation -->
 </dependencies>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,22 +19,25 @@ buildscript {
 }
 
 dependencies {
-    compile 'com.fasterxml.jackson.core:jackson-core:2.3.0'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.3.0'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:2.3.0'
-    compile 'com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.3.0'
+    compile 'com.fasterxml.jackson.core:jackson-core:2.5.3'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.5.3'
+    compile 'com.fasterxml.jackson.core:jackson-annotations:2.5.3'
+    compile 'com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.5.3'
 
-    compile 'org.apache.cxf:cxf-rt-rs-client:3.0.3'
-    compile 'org.apache.cxf:cxf-rt-transports-http-hc:3.0.3'
+    compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
+
 
     compile 'javax.annotation:javax.annotation-api:1.2'
 
     compile 'org.apache.commons:commons-lang3:3.0'
-    compile 'com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.3.0'
-    compile 'com.google.guava:guava:17.0'
+    compile 'com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.5.3'
+    compile 'com.google.guava:guava:18.0'
     compile 'commons-codec:commons-codec:1.9'
 
-    testCompile 'junit:junit:4.11'
+    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.0.3'
+    testCompile 'org.apache.cxf:cxf-rt-transports-http-hc:3.0.3'
+
+    testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-all:1.9.5'
 }
 


### PR DESCRIPTION
Hi, I've been working on integrating this project with dropwizard, and ran into some issues around how the apache cxf stuff plays with the maven-shade plugin.  I was able to work around them, but then realized  that since you've been so awesome as to code to javax.ws.rs-api, it might be better just to use the jersey implementation that i already had on hand.

I'm aware this can be done with excludes as well, but as a user i'd prefer explicit failure when no implementation is specified rather than weird failures down the road. 