### PR TITLE
Fix for service health check

### DIFF
--- a/src/main/java/com/orbitz/consul/HealthClient.java
+++ b/src/main/java/com/orbitz/consul/HealthClient.java
@@ -107,10 +107,12 @@ public class HealthClient {
      *
      * @param catalogOptions The catalog specific options to use.
      * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * {@link com.orbitz.consul.model.health.ServiceCheck} objects.
      */
-    public ConsulResponse<List<HealthCheck>> getServiceChecks(String service, CatalogOptions catalogOptions) {
-        return getNodeChecks(service, catalogOptions, QueryOptions.BLANK);
+    public ConsulResponse<List<ServiceCheck>> getServiceChecks(String service, CatalogOptions catalogOptions) {
+    	return response(webTarget.path("service").path(service), catalogOptions,  QueryOptions.BLANK,
+                new GenericType<List<ServiceCheck>>() {
+                });
     }
 
     /**
@@ -120,10 +122,12 @@ public class HealthClient {
      *
      * @param queryOptions The Query Options to use.
      * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * {@link com.orbitz.consul.model.health.ServiceCheck} objects.
      */
-    public ConsulResponse<List<HealthCheck>> getServiceChecks(String service, QueryOptions queryOptions) {
-        return getNodeChecks(service, null, queryOptions);
+    public ConsulResponse<List<ServiceCheck>> getServiceChecks(String service, QueryOptions queryOptions) {
+    	return response(webTarget.path("service").path(service), null, queryOptions,
+                new GenericType<List<ServiceCheck>>() {
+                });
     }
 
     /**
@@ -134,12 +138,12 @@ public class HealthClient {
      * @param catalogOptions The catalog specific options to use.
      * @param queryOptions   The Query Options to use.
      * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * {@link com.orbitz.consul.model.health.ServiceCheck} objects.
      */
-    public ConsulResponse<List<HealthCheck>> getServiceChecks(String service, CatalogOptions catalogOptions,
+    public ConsulResponse<List<ServiceCheck>> getServiceChecks(String service, CatalogOptions catalogOptions,
                                                               QueryOptions queryOptions) {
-        return response(webTarget.path("checks").path(service), catalogOptions, queryOptions,
-                new GenericType<List<HealthCheck>>() {
+    	return response(webTarget.path("service").path(service), catalogOptions, queryOptions,
+                new GenericType<List<ServiceCheck>>() {
                 });
     }
 
@@ -154,12 +158,12 @@ public class HealthClient {
      * @param queryOptions   The Query Options to use.
      * @param callback       Callback implemented by callee to handle results.
      * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * {@link com.orbitz.consul.model.health.ServiceCheck} objects.
      */
     public void getServiceChecks(String service,
                                  QueryOptions queryOptions,
-                                 ConsulResponseCallback<List<HealthCheck>> callback) {
-        response(webTarget.path("checks").path(service), CatalogOptionsBuilder.builder().build(), queryOptions, new GenericType<List<HealthCheck>>() {
+                                 ConsulResponseCallback<List<ServiceCheck>> callback) {
+        response(webTarget.path("checks").path(service), CatalogOptionsBuilder.builder().build(), queryOptions, new GenericType<List<ServiceCheck>>() {
         }, callback);
     }
 

--- a/src/main/java/com/orbitz/consul/HealthClient.java
+++ b/src/main/java/com/orbitz/consul/HealthClient.java
@@ -4,6 +4,7 @@ import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.model.State;
 import com.orbitz.consul.model.health.HealthCheck;
+import com.orbitz.consul.model.health.ServiceCheck;
 import com.orbitz.consul.model.health.ServiceHealth;
 import com.orbitz.consul.option.CatalogOptions;
 import com.orbitz.consul.option.CatalogOptionsBuilder;
@@ -91,10 +92,12 @@ public class HealthClient {
      * GET /v1/health/service/{service}
      *
      * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * {@link com.orbitz.consul.model.health.ServiceCheck} objects.
      */
-    public ConsulResponse<List<HealthCheck>> getServiceChecks(String service) {
-        return getNodeChecks(service, null, QueryOptions.BLANK);
+    public ConsulResponse<List<ServiceCheck>> getServiceChecks(String service) {
+    	return response(webTarget.path("service").path(service), null, QueryOptions.BLANK,
+                new GenericType<List<ServiceCheck>>() {
+                });
     }
 
     /**

--- a/src/main/java/com/orbitz/consul/model/health/ServiceCheck.java
+++ b/src/main/java/com/orbitz/consul/model/health/ServiceCheck.java
@@ -1,0 +1,31 @@
+package com.orbitz.consul.model.health;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ServiceCheck {
+	
+	@JsonProperty("Node")
+	private Node node;
+
+	@JsonProperty("Service")
+	private Service service;
+
+	@JsonProperty("Checks")
+	private List<HealthCheck> checks;
+	
+	public Node getNode(){
+		return node;
+	}
+	
+	public Service getService(){
+		return service;
+	}
+	
+	public List<HealthCheck> getChecks(){
+		return checks;
+	}
+}

--- a/src/main/java/com/orbitz/consul/option/QueryOptions.java
+++ b/src/main/java/com/orbitz/consul/option/QueryOptions.java
@@ -9,8 +9,9 @@ public class QueryOptions {
     private String wait;
     private int index;
     private ConsistencyMode consistencyMode;
+    private boolean passing;
 
-    public static QueryOptions BLANK = new QueryOptions(null, 0, ConsistencyMode.DEFAULT);
+    public static QueryOptions BLANK = new QueryOptions(null, 0, ConsistencyMode.DEFAULT, false);
 
     /**
      * @param wait Wait string, e.g. "10s" or "10m"
@@ -22,6 +23,21 @@ public class QueryOptions {
         this.index = index;
         this.consistencyMode = consistencyMode;
         this.blocking = wait != null;
+    }
+    
+    /**
+     * @param wait Wait string, e.g. "10s" or "10m"
+     * @param index Lock index.
+     * @param consistencyMode Consistency mode to use for query.
+     * @param passing query parameter, added in Consul 0.2, will filter results to only nodes with all checks in the passing state. This can be used to avoid extra filtering logic on the client side
+     */
+    QueryOptions(String wait, int index, ConsistencyMode consistencyMode, boolean passing) {
+        this(wait, index, consistencyMode);
+        this.passing = passing;
+    }
+    
+    public boolean passing(){
+    	return passing;
     }
 
     public String getWait() {

--- a/src/main/java/com/orbitz/consul/option/QueryOptionsBuilder.java
+++ b/src/main/java/com/orbitz/consul/option/QueryOptionsBuilder.java
@@ -8,6 +8,7 @@ public class QueryOptionsBuilder {
     private String wait;
     private int index;
     private ConsistencyMode consistencyMode = ConsistencyMode.DEFAULT;
+    private boolean passing;
 
     private QueryOptionsBuilder() {
 
@@ -37,16 +38,22 @@ public class QueryOptionsBuilder {
         return this;
     }
 
+    public QueryOptionsBuilder passing() {
+        this.passing = true;
+
+        return this;
+    }
 
     public QueryOptionsBuilder queryOptions(QueryOptions queryOptions) {
         this.wait = queryOptions.getWait();
         this.index = queryOptions.getIndex();
         this.consistencyMode = queryOptions.getConsistencyMode();
+        this.passing = queryOptions.passing();
 
         return this;
     }
 
     public QueryOptions build() {
-        return new QueryOptions(wait, index, consistencyMode);
+        return new QueryOptions(wait, index, consistencyMode, passing);
     }
 }

--- a/src/main/java/com/orbitz/consul/util/ClientUtil.java
+++ b/src/main/java/com/orbitz/consul/util/ClientUtil.java
@@ -51,6 +51,10 @@ public class ClientUtil {
         if(queryOptions.getConsistencyMode() == ConsistencyMode.STALE) {
             webTarget = webTarget.queryParam("stale");
         }
+        
+        if(queryOptions.passing()){
+        	webTarget = webTarget.queryParam("passing");
+        }
 
         return webTarget;
     }
@@ -113,7 +117,6 @@ public class ClientUtil {
 
     public static <T> ConsulResponse<T> response(WebTarget webTarget, GenericType<T> responseType) {
         Response response = webTarget.request().accept(MediaType.APPLICATION_JSON_TYPE).get();
-
         return consulResponse(responseType, response);
     }
 

--- a/src/test/java/com/orbitz/consul/HealthTests.java
+++ b/src/test/java/com/orbitz/consul/HealthTests.java
@@ -4,9 +4,11 @@ import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.model.State;
 import com.orbitz.consul.model.agent.Registration;
 import com.orbitz.consul.model.health.HealthCheck;
+import com.orbitz.consul.model.health.ServiceCheck;
 import com.orbitz.consul.model.health.ServiceHealth;
 import com.orbitz.consul.option.CatalogOptionsBuilder;
 import com.orbitz.consul.option.QueryOptionsBuilder;
+
 import org.junit.Test;
 
 import java.net.UnknownHostException;
@@ -101,16 +103,21 @@ public class HealthTests {
         client.agentClient().pass(serviceId);
 
         boolean found = false;
-        ConsulResponse<List<HealthCheck>> response = client.healthClient().getServiceChecks(serviceName,
+        ConsulResponse<List<ServiceCheck>> response = client.healthClient().getServiceChecks(serviceName,
                 CatalogOptionsBuilder.builder().datacenter("dc1").build(),
                 QueryOptionsBuilder.builder().blockSeconds(20, 0).build());
 
-        List<HealthCheck> checks = response.getResponse();
+        List<ServiceCheck> checks = response.getResponse();
         assertEquals(1, checks.size());
-        for(HealthCheck ch : checks) {
-            if(ch.getServiceId().equals(serviceId)) {
-                found = true;
+        for(ServiceCheck chs : checks) {
+            for(HealthCheck ch : chs.getChecks()){
+            	if(ch.getServiceId().equals(serviceId)) {
+                    found = true;
+                    break;
+                }
             }
+            if(found)
+            	break;
         }
         assertTrue(found);
     }


### PR DESCRIPTION
Some changes for [/v1/health/service/<service>](http://www.consul.io/docs/agent/http/health.html#health_service)
1) Before getNodeChecks([/v1/health/node/{node}](http://www.consul.io/docs/agent/http/health.html#health_node)) was called. 
2) `Passing` option was added.
Providing the "?passing" query parameter, added in Consul 0.2, will filter results to only nodes with all checks in the passing state. This can be used to avoid extra filtering logic on the client side.