### PR TITLE
Create new client url method

### DIFF
--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -61,7 +61,7 @@ public class Consul {
      */	
 	public static Consul newClient(String url, ClientBuilder builder) {
         try {
-            return new Consul(new URL(url).toString(), builder);
+            return new Consul(url, builder);
         } catch (MalformedURLException e) {
             throw new ConsulException("Bad Consul URL", e);
         }

--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -51,6 +51,21 @@ public class Consul {
 
         agentClient.ping();
     }
+	
+   /**
+     * Creates a new client given a complete URL.
+     *
+     * @param url The Consul API URL.
+     * @param builder The JAX-RS client builder instance.
+     * @return A new client.
+     */	
+	public static Consul newClient(String url, ClientBuilder builder) {
+        try {
+            return new Consul(new URL(url).toString(), builder);
+        } catch (MalformedURLException e) {
+            throw new ConsulException("Bad Consul URL", e);
+        }
+    }
 
     /**
      * Creates a new client given a host and a port.

--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -60,11 +60,7 @@ public class Consul {
      * @return A new client.
      */	
 	public static Consul newClient(String url, ClientBuilder builder) {
-        try {
-            return new Consul(url, builder);
-        } catch (MalformedURLException e) {
-            throw new ConsulException("Bad Consul URL", e);
-        }
+       return new Consul(url, builder);
     }
 
     /**


### PR DESCRIPTION
Hello Rick, hi folks,

Would be very useful to create a consul client just from a given url, like the standard constructor does. 

For example do we use HTTPS tunneling to our consul cloud instance and our host uses some url rewriting that we can't avoid in URL path. So best deal will be to directly choose the target url as string for us.

Kind regards,
Robin