### PR TITLE
add acl token to QueryOptions

### DIFF
--- a/src/main/java/com/orbitz/consul/option/QueryOptions.java
+++ b/src/main/java/com/orbitz/consul/option/QueryOptions.java
@@ -9,19 +9,23 @@ public class QueryOptions {
     private String wait;
     private int index;
     private ConsistencyMode consistencyMode;
+    private boolean authenticated;
+    private String token;
 
-    public static QueryOptions BLANK = new QueryOptions(null, 0, ConsistencyMode.DEFAULT);
+    public static QueryOptions BLANK = new QueryOptions(null, 0, ConsistencyMode.DEFAULT, null);
 
     /**
      * @param wait Wait string, e.g. "10s" or "10m"
      * @param index Lock index.
      * @param consistencyMode Consistency mode to use for query.
      */
-    QueryOptions(String wait, int index, ConsistencyMode consistencyMode) {
+    QueryOptions(String wait, int index, ConsistencyMode consistencyMode, String token) {
         this.wait = wait;
         this.index = index;
         this.consistencyMode = consistencyMode;
         this.blocking = wait != null;
+        this.token = token;
+        this.authenticated = token != null;
     }
 
     public String getWait() {
@@ -39,4 +43,8 @@ public class QueryOptions {
     public boolean isBlocking() {
         return blocking;
     }
+
+    public boolean hasToken() { return authenticated; }
+
+    public String getToken() { return token; }
 }

--- a/src/main/java/com/orbitz/consul/option/QueryOptionsBuilder.java
+++ b/src/main/java/com/orbitz/consul/option/QueryOptionsBuilder.java
@@ -8,6 +8,7 @@ public class QueryOptionsBuilder {
     private String wait;
     private int index;
     private ConsistencyMode consistencyMode = ConsistencyMode.DEFAULT;
+    private String token;
 
     private QueryOptionsBuilder() {
 
@@ -15,6 +16,11 @@ public class QueryOptionsBuilder {
 
     public static QueryOptionsBuilder builder() {
         return new QueryOptionsBuilder();
+    }
+
+    public QueryOptionsBuilder withToken(String token) {
+        this.token = token;
+        return this;
     }
 
     public QueryOptionsBuilder blockMinutes(int minutes, int index) {
@@ -47,6 +53,6 @@ public class QueryOptionsBuilder {
     }
 
     public QueryOptions build() {
-        return new QueryOptions(wait, index, consistencyMode);
+        return new QueryOptions(wait, index, consistencyMode, token);
     }
 }

--- a/src/main/java/com/orbitz/consul/util/ClientUtil.java
+++ b/src/main/java/com/orbitz/consul/util/ClientUtil.java
@@ -66,6 +66,10 @@ public class ClientUtil {
             webTarget = webTarget.queryParam("stale");
         }
 
+        if(queryOptions.hasToken()){
+            webTarget = webTarget.queryParam("token",queryOptions.getToken());
+        }
+
         return webTarget;
     }
 


### PR DESCRIPTION
Hi. I'm not sure if this is how you want to handle Consul ACL's. The alternative would be specifying them when creating the client. Adding the param to QueryOptions was such a small change i went ahead and did it.

I started on PutOptions, but realized delete takes a Map.

I hope this is helpful, and you're welcome to it, but it seems like there would be api changes (rather than just additions) to get auth supported everywhere.