### PR TITLE
added the ability to register an application-level check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.travis.yml eol=lf
+.git* text eol=lf
+gradlew text oel=lf

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven'
 
-version = '0.9.3'
+version = '0.9.4-SNAPSHOT'
 group = 'com.orbitz.consul'
 
 repositories {

--- a/src/main/java/com/orbitz/consul/model/agent/Check.java
+++ b/src/main/java/com/orbitz/consul/model/agent/Check.java
@@ -27,6 +27,17 @@ public class Check {
     @JsonProperty("HTTP")
     private String http;
 
+    @JsonProperty("Service_id")
+    private String serviceId;
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public void setServiceId(String serviceId) {
+        this.serviceId = serviceId;
+    }
+
     public String getId() {
         return id;
     }


### PR DESCRIPTION
An application-level check is bound to a specific service. This kind of check only affects the availability of the service instead of the entire Consul instance