### PR TITLE
Asynchronous key/value store

### DIFF
--- a/src/main/java/com/orbitz/consul/KeyValueClient.java
+++ b/src/main/java/com/orbitz/consul/KeyValueClient.java
@@ -2,8 +2,10 @@ package com.orbitz.consul;
 
 import com.google.common.base.Optional;
 import com.google.common.primitives.UnsignedLongs;
-import com.orbitz.consul.model.session.SessionInfo;
+import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.kv.Value;
+import com.orbitz.consul.model.session.SessionInfo;
+import com.orbitz.consul.option.CatalogOptionsBuilder;
 import com.orbitz.consul.option.PutOptions;
 import com.orbitz.consul.option.PutOptionsBuilder;
 import com.orbitz.consul.option.QueryOptions;
@@ -19,6 +21,7 @@ import javax.ws.rs.core.Response;
 import java.util.*;
 
 import static com.orbitz.consul.util.ClientUtil.decodeBase64;
+import static com.orbitz.consul.util.ClientUtil.response;
 
 /**
  * HTTP Client for /v1/kv/ endpoints.
@@ -74,6 +77,21 @@ public class KeyValueClient {
     }
 
     /**
+     * Asynchronously retrieves a {@link com.orbitz.consul.model.kv.Value} for a specific key
+     * from the key/value store.
+     *
+     * GET /v1/keyValue/{key}
+     *
+     * @param key The key to retrieve.
+     * @param queryOptions The query options.
+     * @param callback Callback implemented by callee to handle results.
+     */
+    public void getValue(String key, QueryOptions queryOptions, ConsulResponseCallback<List<Value>> callback) {
+        response(webTarget.path(key), CatalogOptionsBuilder.builder().build(), queryOptions,
+                new GenericType<List<Value>>() {}, callback);
+    }
+
+    /**
      * Retrieves a list of {@link com.orbitz.consul.model.kv.Value} objects for a specific key
      * from the key/value store.
      *
@@ -87,6 +105,21 @@ public class KeyValueClient {
 
         return Arrays.asList(target
                 .request().accept(MediaType.APPLICATION_JSON_TYPE).get(Value[].class));
+    }
+
+    /**
+     * Asynchronously retrieves a list of {@link com.orbitz.consul.model.kv.Value} objects for a specific key
+     * from the key/value store.
+     *
+     * GET /v1/keyValue/{key}?recurse
+     *
+     * @param key The key to retrieve.
+     * @param queryOptions The query options.
+     * @param callback Callback implemented by callee to handle results.
+     */
+    public void getValues(String key, QueryOptions queryOptions, ConsulResponseCallback<List<Value>> callback) {
+        response(webTarget.path(key).queryParam("recurse", "true"), CatalogOptionsBuilder.builder().build(),
+                queryOptions, new GenericType<List<Value>>() {}, callback);
     }
 
     /**

--- a/src/main/java/com/orbitz/consul/option/QueryOptions.java
+++ b/src/main/java/com/orbitz/consul/option/QueryOptions.java
@@ -7,7 +7,7 @@ public class QueryOptions {
 
     private boolean blocking;
     private String wait;
-    private int index;
+    private long index;
     private ConsistencyMode consistencyMode;
     private boolean authenticated;
     private String token;
@@ -19,7 +19,7 @@ public class QueryOptions {
      * @param index Lock index.
      * @param consistencyMode Consistency mode to use for query.
      */
-    QueryOptions(String wait, int index, ConsistencyMode consistencyMode, String token) {
+    QueryOptions(String wait, long index, ConsistencyMode consistencyMode, String token) {
         this.wait = wait;
         this.index = index;
         this.consistencyMode = consistencyMode;
@@ -32,7 +32,7 @@ public class QueryOptions {
         return wait;
     }
 
-    public int getIndex() {
+    public long getIndex() {
         return index;
     }
 

--- a/src/main/java/com/orbitz/consul/option/QueryOptionsBuilder.java
+++ b/src/main/java/com/orbitz/consul/option/QueryOptionsBuilder.java
@@ -6,7 +6,7 @@ package com.orbitz.consul.option;
 public class QueryOptionsBuilder {
 
     private String wait;
-    private int index;
+    private long index;
     private ConsistencyMode consistencyMode = ConsistencyMode.DEFAULT;
     private String token;
 
@@ -23,14 +23,14 @@ public class QueryOptionsBuilder {
         return this;
     }
 
-    public QueryOptionsBuilder blockMinutes(int minutes, int index) {
+    public QueryOptionsBuilder blockMinutes(int minutes, long index) {
         this.wait = String.format("%sm", minutes);
         this.index = index;
 
         return this;
     }
 
-    public QueryOptionsBuilder blockSeconds(int seconds, int index) {
+    public QueryOptionsBuilder blockSeconds(int seconds, long index) {
         this.wait = String.format("%ss", seconds);
         this.index = index;
 


### PR DESCRIPTION
I added two methods to get `Value` objects from the key/value store asynchronously and to watch for changes.

I also changed the index variable from int to long in the `QueryOptionsBuilder` and `QueryOptions` to reflect the changes made to `ConsulResponse`. Is this ok or should I open a separate PR?