### PR TITLE
Fixes logging error in ConsulCache

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.option.QueryOptions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,7 +83,7 @@ public class ConsulCache<K, V> {
             @Override
             public void onFailure(Throwable throwable) {
 
-                LOGGER.error("Error getting response from consul. will retry in {} {}", backoffDelayQty, backoffDelayUnit, throwable);
+                LOGGER.error(String.format("Error getting response from consul. will retry in %d %s", backoffDelayQty, backoffDelayUnit), throwable);
 
                 executorService.schedule(new Runnable() {
                     @Override


### PR DESCRIPTION
If ConsulCache loses a connection to the agent then it will get an onFailure notification. That handler logs the error and then attempts to reconnect. However, the log line is malformed as a logger.error(...) cannot accept both string arguments and a throwable. This commit fixes that by putting the message + args in a String.format(...). This allows us to call LOGGER.error(String, Throwable).