### PR TITLE
Improves compatibility with Resteasy though ContextResolvers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,10 @@ dependencies {
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile 'javax.annotation:javax.annotation-api:1.2'
 
-    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.0.3'
-    testCompile 'org.apache.cxf:cxf-rt-transports-http-hc:3.0.3'
+//    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.0.3'
+//    testCompile 'org.apache.cxf:cxf-rt-transports-http-hc:3.0.3'
+    testCompile 'org.jboss.resteasy:resteasy-jackson2-provider:3.0.14.Final'
+    testCompile 'org.jboss.resteasy:resteasy-client:3.0.14.Final'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-all:1.9.5'

--- a/src/main/java/com/orbitz/consul/util/ObjectMapperContextResolver.java
+++ b/src/main/java/com/orbitz/consul/util/ObjectMapperContextResolver.java
@@ -1,0 +1,19 @@
+package com.orbitz.consul.util;
+
+import javax.ws.rs.ext.ContextResolver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ObjectMapperContextResolver implements ContextResolver<ObjectMapper> {
+
+    private final ObjectMapper objectMapper;
+    public ObjectMapperContextResolver(final ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+    
+    @Override
+    public ObjectMapper getContext(final Class<?> type) {
+        return objectMapper;
+    }
+
+}


### PR DESCRIPTION
@rickfast 

Semi-related to here where I brought up a related issue: https://github.com/OrbitzWorldwide/consul-client/issues/76

JBoss/Wildfly includes an implementation of ```JacksonJaxbJsonProvider``` on the classpath (e.g. resteasy-jackson2-provider) which is picked up by the JAX-RS client runtime (e.g. resteasy-client). So, the result is the ```JacksonJaxbJsonProvider``` declared by Consul-client is effectively ignored or may be ignored (I don't know if there is a way to define an order or priority among providers, it might be effectively whichever gets registered first wins), and as a result the Guava module is never loaded, and many interesting deserialization problems ensue, for example:

```
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Can not construct instance of com.google.common.base.Optional, problem: abstract types either need to be mapped to concrete types, have custom deserializer, or be instantiated with additional type information
 at [Source: org.apache.http.conn.EofSensorInputStream@406292dc; line: 1, column: 78] (through reference chain: java.util.ArrayList[0]->com.orbitz.consul.model.kv.ImmutableValue["Value"])
```

So, instead of setting the mapper on the provider, I declared a ```ContextResolver<ObjectMapper>``` and registered that, so it will be picked up by *any* message body reader/writer implementation already registered. Additionally I check to see if we already have a ```JacksonJaxbJsonProvider``` registered and skip adding a new one if there is one there already. Seems safe since you don't seem to be doing anything special with it, but if you were, it might be very difficult to get this to play nicely in JEE Wildfly land :disappointed: .

For testing, I just switched the jax.ws.rs runtime to Resteasy, but both Resteasy and Apache CXF seem to like this new setup. I might need something fancier like Shrinkwrap to play around with different classpath configurations if you wanted to be able to test against both during your build, and I am not sure if you have an interest in adding Resteasy as a test dependency, but let me know.

Anyway, cool library, planning to add vault support anytime soon? :smile:  