### PR TITLE
KVClient: PutOptions.getCas should be long, not int

### DIFF
--- a/src/main/java/com/orbitz/consul/option/PutOptions.java
+++ b/src/main/java/com/orbitz/consul/option/PutOptions.java
@@ -12,7 +12,7 @@ public abstract class PutOptions implements ParamAdder {
     
     public static final PutOptions BLANK = ImmutablePutOptions.builder().build();
     
-    public abstract Optional<Integer> getCas();
+    public abstract Optional<Long> getCas();
     public abstract Optional<String> getAcquire();
     public abstract Optional<String> getRelease();
     public abstract Optional<String> getDc();


### PR DESCRIPTION
A pull-request for [this issue](https://github.com/OrbitzWorldwide/consul-client/issues/107).