### PR TITLE
Add support for OSGi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.orbitz.consul</groupId>
     <artifactId>consul-client</artifactId>
-    <packaging>jar</packaging>
-    <version>0.11.0</version>
+    <packaging>bundle</packaging>
+    <version>0.11.1-SNAPSHOT</version>
     <name>consul-client</name>
     <url>http://maven.apache.org</url>
     <description>Consul Client for Java</description>
@@ -27,6 +27,9 @@
             <email>rick.t.fast@gmail.com</email>
         </developer>
     </developers>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
@@ -163,6 +166,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -175,6 +179,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.3</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -261,6 +266,52 @@
                                 </relocation>
                             </relocations>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.0.1</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId} </Bundle-SymbolicName>
+                        <Bundle-Name>OrbitzWorldwide :: ${project.artifactId}</Bundle-Name>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                        <Export-Package>
+                            com.orbitz.consul*;-noimport:=true,
+                            com.orbitz.google.common.base,
+                            !com.orbitz.retrofit*,
+                            !com.orbitz.squareup*,
+                            !com.orbitz.okio*,
+                            !com.orbitz.okhttp3*,                            
+                            !com.orbitz.fasterxml*,
+                            !com.orbitz.apache*
+                        </Export-Package>
+                        <Import-Package>
+                            !retrofit2*,
+                            !com.squareup*,
+                            !okio*,
+                            !okhttp3*,
+                            !com.google*,
+                            !com.fasterxml*,
+                            !org.apache*,
+                            javax.net,
+                            javax.net.ssl,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <!--
+                      This execution makes sure that the manifest is available
+                      when the tests are executed
+                    -->
+                    <execution>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
I've added support for OSGi after the migration to maven and shaded packages and below is how the bundle looks in Apache Karaf:

```
OrbitzWorldwide :: consul-client (64)
-------------------------------------
Bnd-LastModified = 1462180954009
Build-Jdk = 1.8.0_92
Built-By = lburgazz
Created-By = Apache Maven Bundle Plugin
Manifest-Version = 1.0
Tool = Bnd-3.0.0.201509101326

Bundle-Description = Consul Client for Java
Bundle-License = http://www.apache.org/licenses/LICENSE-2.0.txt
Bundle-ManifestVersion = 2
Bundle-Name = OrbitzWorldwide :: consul-client
Bundle-SymbolicName = com.orbitz.consul.consul-client
Bundle-Version = 0.11.1.SNAPSHOT

Require-Capability = 
	osgi.ee;filter:=(&(osgi.ee=JavaSE)(version=1.7))

Export-Package = 
	com.orbitz.consul;
		uses:="com.orbitz.consul.async,
			com.orbitz.consul.model,
			com.orbitz.consul.model.agent,
			com.orbitz.consul.model.catalog,
			com.orbitz.consul.model.event,
			com.orbitz.consul.model.health,
			com.orbitz.consul.model.kv,
			com.orbitz.consul.model.query,
			com.orbitz.consul.model.session,
			com.orbitz.consul.option,
			javax.net.ssl";
		version=0.11.1.SNAPSHOT,
	com.orbitz.consul.async;uses:=com.orbitz.consul.model;version=0.11.1.SNAPSHOT,
	com.orbitz.consul.cache;uses:="com.orbitz.consul,com.orbitz.consul.async,com.orbitz.consul.model.health,com.orbitz.consul.model.kv,com.orbitz.consul.option";version=0.11.1.SNAPSHOT,
	com.orbitz.consul.model;uses:=com.orbitz.consul.model.event;version=0.11.1.SNAPSHOT,
	com.orbitz.consul.model.acl;version=0.11.1.SNAPSHOT,
	com.orbitz.consul.model.agent;version=0.11.1.SNAPSHOT,
	com.orbitz.consul.model.catalog;uses:=com.orbitz.consul.model.health;version=0.11.1.SNAPSHOT,
	com.orbitz.consul.model.event;uses:=com.orbitz.consul.util;version=0.11.1.SNAPSHOT,
	com.orbitz.consul.model.health;version=0.11.1.SNAPSHOT,
	com.orbitz.consul.model.kv;uses:=com.orbitz.consul.util;version=0.11.1.SNAPSHOT,
	com.orbitz.consul.model.query;uses:=com.orbitz.consul.model.health;version=0.11.1.SNAPSHOT,
	com.orbitz.consul.model.session;uses:=com.orbitz.consul.util;version=0.11.1.SNAPSHOT,
	com.orbitz.consul.option;version=0.11.1.SNAPSHOT,
	com.orbitz.consul.util;uses:="com.orbitz.consul,com.orbitz.consul.async,com.orbitz.consul.model";version=0.11.1.SNAPSHOT,
	com.orbitz.google.common.base;version=0.11.1.SNAPSHOT
Import-Package = 
	javax.net.ssl,
	org.slf4j;version="[1.7,2)",
	javax.net
```

Because of shaded packages I had to tweak packages's import/export in particular to expose Guava's Optional class. It seems to work for basic tests but it may need some additional tweaks.

