### PR TITLE
Introduced acl and auth support

### DIFF
--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -3,6 +3,7 @@ package com.orbitz.consul;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.io.BaseEncoding;
 import com.google.common.net.HostAndPort;
 import com.orbitz.consul.util.Jackson;
 import okhttp3.*;
@@ -223,7 +224,7 @@ public class Consul {
          */
         public Builder withBasicAuth(String username, String password) {
             String credentials = username + ":" + password;
-            final String basic = "Basic " + java.util.Base64.getEncoder().encodeToString(credentials.getBytes());
+            final String basic = "Basic " + BaseEncoding.base64().encode(credentials.getBytes());
             basicAuthInterceptor = new Interceptor() {
                 @Override
                 public Response intercept(Chain chain) throws IOException {


### PR DESCRIPTION
basic support for the Consul ACL (providing token) + support for Basic Authentication (providing username+password)

Added support for the Consul ACL : a token can be provided to the Consul.Builder, this token will be added to every request as a query parameter.

Added support for Basic Authentication : in case you setup a reverse proxy in front of the Consul service (for additional security to the ACL, or as an alternative to the Consul ACL)

In both case, an Interceptor is added to the Retrofit client.