### PR TITLE
Add compatibility with Consul v0.6.4, update libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
   - oraclejdk7
 before_install:
-  - wget https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip --no-check-certificate
-  - unzip consul_0.5.2_linux_amd64.zip
+  - wget https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip --no-check-certificate
+  - unzip consul_0.6.4_linux_amd64.zip
   - ./consul agent -server -bootstrap -data-dir data &
 script: mvn clean test

--- a/pom.xml
+++ b/pom.xml
@@ -66,53 +66,53 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>19.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.6.3</version>
+            <version>2.7.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.6.3</version>
+            <version>2.7.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.3</version>
+            <version>2.7.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-guava</artifactId>
-            <version>2.6.3</version>
+            <version>2.7.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.2.1</version>
+            <version>3.4</version>
         </dependency>
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
-            <version>2.1.12</version>
+            <version>2.1.19</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.12</version>
+            <version>1.7.21</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -195,7 +195,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.5.1</version>
                 <configuration>
                     <source>7</source>
                     <target>7</target>
@@ -204,12 +204,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.14.1</version>
+                <version>2.19.1</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.surefire</groupId>
                         <artifactId>surefire-junit47</artifactId>
-                        <version>2.14.1</version>
+                        <version>2.19.1</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/main/java/com/orbitz/consul/model/agent/Config.java
+++ b/src/main/java/com/orbitz/consul/model/agent/Config.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import org.immutables.value.Value;
 
@@ -57,8 +58,13 @@ public abstract class Config {
     @JsonProperty("SkipLeaveOnInt")
     public abstract boolean getSkipLeaveOnInt();
 
+    /**
+     *
+     * @deprecated GET /v1/agent/self of Consul v0.6.4 dose not have that field
+     */
+    @Deprecated
     @JsonProperty("StatsiteAddr")
-    public abstract String getStatsiteAddr();
+    public abstract Optional<String> getStatsiteAddr();
 
     @JsonProperty("Protocol")
     public abstract int getProtocol();
@@ -96,4 +102,11 @@ public abstract class Config {
 
     @JsonProperty("RejoinAfterLeave")
     public abstract boolean getRejoinAfterLeave();
+
+    /**
+     * New version of consul has Telemetry field
+     * TODO: Have to think about back compatibility (I think we shouldn't)
+     */
+    @JsonProperty("Telemetry")
+    public abstract Optional<Telemetry> getTelemetry();
 }

--- a/src/main/java/com/orbitz/consul/model/agent/Telemetry.java
+++ b/src/main/java/com/orbitz/consul/model/agent/Telemetry.java
@@ -1,0 +1,34 @@
+package com.orbitz.consul.model.agent;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Optional;
+import org.immutables.value.Value;
+
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableTelemetry.class)
+@JsonDeserialize(as = ImmutableTelemetry.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class Telemetry {
+    @JsonProperty(value = "StatsiteAddr")
+    public abstract String getStatsiteAddr();
+
+    @JsonProperty(value = "StatsdAddr")
+    public abstract String getStatsdAddr();
+
+    @JsonProperty(value = "StatsitePrefix")
+    public abstract String getStatsitePrefix();
+
+    @JsonProperty(value = "DisableHostname")
+    public abstract Boolean getDisableHostname();
+
+    @JsonProperty(value = "DogStatsdAddr")
+    public abstract String getDogStatsdAddr();
+
+    @JsonProperty(value = "DogStatsdTags")
+    // TODO: array?
+    public abstract Optional<String> getDogStatsdTags();
+}


### PR DESCRIPTION
Here in this pull request:

- Make compatible with the latest Consul v0.6.4, still back compatible with the previous one (but do we really need that?), GET /v1/agent/self was failing
- Add Telemetry field to JSON of GET /v1/agent/self, marked optional
- Bump maven-compiler-plugin version to fix the known bug when recompiling: https://github.com/mkarneim/pojobuilder/issues/71#issuecomment-204052989
- Fix failing tests
- Add lock acquire test
- Bump all the libs to latest stable version

Please let me know do you interested in another fixes. I'm making a deep integration of Consul using consul-client into my project, having some troubles and fixing them on my own, like to be engaged into big deal. I'm really interested to contribute to consul-client.

Thanks.