### PR TITLE
Adds HealthCheckCache for health api /v1/health/state/<state>

### DIFF
--- a/src/main/java/com/orbitz/consul/HealthClient.java
+++ b/src/main/java/com/orbitz/consul/HealthClient.java
@@ -242,6 +242,24 @@ public class HealthClient {
     }
 
     /**
+     * Asynchronously retrieves the healthchecks for a state in a given datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     *
+     * GET /v1/health/state/{state}?dc={datacenter}
+     *
+     * @param state          The state to query.
+     * @param catalogOptions The catalog specific options to use.
+     * @param queryOptions   The Query Options to use.
+     * @param callback       Callback implemented by callee to handle results.
+     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
+     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     */
+    public void getChecksByState(State state, CatalogOptions catalogOptions,
+                                                              QueryOptions queryOptions,
+                                                              ConsulResponseCallback<List<HealthCheck>> callback) {
+        extractConsulResponse(api.getChecksByState(state.getName(), Options.from(catalogOptions, queryOptions)), callback);
+    }
+
+    /**
      * Retrieves the healthchecks for all healthy service instances.
      *
      * GET /v1/health/service/{service}?passing

--- a/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
+++ b/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
@@ -1,0 +1,56 @@
+package com.orbitz.consul.cache;
+
+import com.google.common.base.Function;
+import com.google.common.net.HostAndPort;
+import com.orbitz.consul.HealthClient;
+import com.orbitz.consul.async.ConsulResponseCallback;
+import com.orbitz.consul.model.health.HealthCheck;
+import com.orbitz.consul.model.health.ServiceHealth;
+import com.orbitz.consul.option.CatalogOptions;
+
+import java.math.BigInteger;
+import java.util.List;
+
+public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
+
+    private HealthCheckCache(Function<HealthCheck, String> keyConversion, CallbackConsumer<HealthCheck> callbackConsumer) {
+        super(keyConversion, callbackConsumer);
+    }
+
+    /**
+     * Factory method to construct a string/{@link HealthCheck} map for a particular {@link com.orbitz.consul.model.State}.
+     * <p/>
+     * Keys will be the {@link HealthCheck#getCheckId()}.
+     *
+     * @param healthClient the {@link HealthClient}
+     * @param state        the state fo filter checks
+     * @return a cache object
+     */
+    public static HealthCheckCache newCache(
+            final HealthClient healthClient,
+            final com.orbitz.consul.model.State state,
+            final CatalogOptions catalogOptions,
+            final int watchSeconds) {
+        Function<HealthCheck, String> keyExtractor = new Function<HealthCheck, String>() {
+            @Override
+            public String apply(HealthCheck input) {
+                return input.getCheckId();
+            }
+        };
+
+        CallbackConsumer<HealthCheck> callbackConsumer = new CallbackConsumer<HealthCheck>() {
+            @Override
+            public void consume(BigInteger index, ConsulResponseCallback<List<HealthCheck>> callback) {
+                healthClient.getChecksByState(state, catalogOptions, watchParams(index, watchSeconds), callback);
+            }
+        };
+
+        return new HealthCheckCache(keyExtractor, callbackConsumer);
+
+    }
+
+    public static HealthCheckCache newCache(final HealthClient healthClient, final com.orbitz.consul.model.State state) {
+        return newCache(healthClient, state, CatalogOptions.BLANK, 10);
+    }
+
+}


### PR DESCRIPTION
The `HealthClient` has a api with support for blocking requests that enables us to filter health checks by state. Using `ConsulCache` it is possible to offer the listener functionality for that api as well.

This pull request adds an asynchronous implementation of `HealthClient#getChecksByState`, and an implementation of `ConsulCache` called `HealthCheckCache`, that maps `HealthCheck` by its check id.

We are using this internally already in out stack, hope its all good for you to merge it.

Let me know if there are any issues or something missing that I can fix.
Thanks!