### PR TITLE
Exposes listeners in ConsulCache

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -202,6 +202,14 @@ public class ConsulCache<K, V> {
         return added;
     }
 
+    public Iterable<Listener<K, V>> getListeners() {
+        return listeners;
+    }
+
+    public int getListenersSize() {
+        return listeners.size();
+    }
+
     public boolean removeListener(Listener<K, V> listener) {
         return listeners.remove(listener);
     }

--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -202,12 +203,8 @@ public class ConsulCache<K, V> {
         return added;
     }
 
-    public Iterable<Listener<K, V>> getListeners() {
-        return listeners;
-    }
-
-    public int getListenersSize() {
-        return listeners.size();
+    public List<Listener<K, V>> getListeners() {
+        return Collections.unmodifiableList(listeners);
     }
 
     public boolean removeListener(Listener<K, V> listener) {


### PR DESCRIPTION
Hey, I was wondering if it's ok for you guys to expose the listeners from a `ConsulCache`. We need to access at least the number of listeners registered to a cache, so we can stop it once all listeners are removed, for example.

I've exposed in this pull request the size of the list, plus the list itself as an `Iterable`. Feel free to rename the methods if its not following your code pattern or something.

Thanks again!