### PR TITLE
Tests using embedded-consul instead of travis.yml script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: java
 jdk:
   - oraclejdk7
-before_install:
-  - wget https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip --no-check-certificate
-  - unzip consul_0.6.4_linux_amd64.zip
-  - ./consul agent -server -bootstrap -data-dir data &
 script: mvn clean test

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,12 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.pszymczyk.consul</groupId>
+            <artifactId>embedded-consul</artifactId>
+            <version>0.1.8</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/src/test/java/com/orbitz/consul/AgentTests.java
+++ b/src/test/java/com/orbitz/consul/AgentTests.java
@@ -24,11 +24,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class AgentTests {
+public class AgentTests extends BaseIntegrationTest {
 
     @Test
     public void shouldRetrieveAgentInformation() throws UnknownHostException {
-        Consul client = Consul.builder().build();
         Agent agent = client.agentClient().getAgent();
 
         assertNotNull(agent);
@@ -37,7 +36,6 @@ public class AgentTests {
 
     @Test
     public void shouldRegisterTtlCheck() throws UnknownHostException, InterruptedException {
-        Consul client = Consul.builder().build();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
@@ -55,12 +53,10 @@ public class AgentTests {
         }
 
         assertTrue(found);
-        client.agentClient().deregister(serviceId);
     }
 
     @Test
     public void shouldRegisterHttpCheck() throws UnknownHostException, InterruptedException, MalformedURLException {
-        Consul client = Consul.builder().build();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
@@ -78,7 +74,6 @@ public class AgentTests {
         }
 
         assertTrue(found);
-        client.agentClient().deregister(serviceId);
     }
 
     // Need to fix tests for 0.6.2
@@ -107,7 +102,6 @@ public class AgentTests {
 
     @Test
     public void shouldRegisterMultipleChecks() throws UnknownHostException, InterruptedException, MalformedURLException {
-        Consul client = Consul.builder().build();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
@@ -129,7 +123,6 @@ public class AgentTests {
         }
 
         assertTrue(found);
-        client.agentClient().deregister(serviceId);
     }
 
     // This is apparently valid
@@ -137,7 +130,6 @@ public class AgentTests {
     // and multiple "Checks" in one call
     @Test
     public void shouldRegisterMultipleChecks2() throws UnknownHostException, InterruptedException, MalformedURLException {
-        Consul client = Consul.builder().build();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
@@ -168,12 +160,10 @@ public class AgentTests {
         }
 
         assertTrue(found);
-        client.agentClient().deregister(serviceId);
     }
 
     @Test
     public void shouldDeregister() throws UnknownHostException, InterruptedException {
-        Consul client = Consul.builder().build();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
@@ -193,7 +183,6 @@ public class AgentTests {
 
     @Test
     public void shouldGetChecks() {
-        Consul client = Consul.builder().build();
         String id = UUID.randomUUID().toString();
         client.agentClient().register(8080, 20L, UUID.randomUUID().toString(), id);
 
@@ -206,12 +195,10 @@ public class AgentTests {
         }
 
         assertTrue(found);
-        client.agentClient().deregister(id);
     }
 
     @Test
     public void shouldGetServices() {
-        Consul client = Consul.builder().build();
         String id = UUID.randomUUID().toString();
         client.agentClient().register(8080, 20L, UUID.randomUUID().toString(), id);
 
@@ -225,12 +212,10 @@ public class AgentTests {
         }
 
         assertTrue(found);
-        client.agentClient().deregister(id);
     }
 
     @Test
     public void shouldSetWarning() throws UnknownHostException, NotRegisteredException {
-        Consul client = Consul.builder().build();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
         String note = UUID.randomUUID().toString();
@@ -239,12 +224,10 @@ public class AgentTests {
         client.agentClient().warn(serviceId, note);
 
         verifyState("warning", client, serviceId, serviceName, note);
-        client.agentClient().deregister(serviceId);
     }
 
     @Test
     public void shouldSetFailing() throws UnknownHostException, NotRegisteredException {
-        Consul client = Consul.builder().build();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
         String note = UUID.randomUUID().toString();
@@ -253,12 +236,10 @@ public class AgentTests {
         client.agentClient().fail(serviceId, note);
 
         verifyState("critical", client, serviceId, serviceName, note);
-        client.agentClient().deregister(serviceId);
     }
 
     @Test
     public void shouldRegisterNodeScriptCheck() throws InterruptedException {
-        Consul client = Consul.builder().build();
         String checkId = UUID.randomUUID().toString();
 
         client.agentClient().registerCheck(checkId, "test-validate", "/usr/bin/echo \"sup\"", 30);
@@ -267,14 +248,11 @@ public class AgentTests {
 
         assertEquals(check.getCheckId(), checkId);
         assertEquals(check.getName(), "test-validate");
-
-        client.agentClient().deregisterCheck(checkId);
     }
 
 
     @Test
     public void shouldRegisterNodeHttpCheck() throws InterruptedException, MalformedURLException {
-        Consul client = Consul.builder().build();
         String checkId = UUID.randomUUID().toString();
 
         client.agentClient().registerCheck(checkId, "test-validate", new URL("http://foo.local:1337/check"), 30);
@@ -283,13 +261,10 @@ public class AgentTests {
 
         assertEquals(check.getCheckId(), checkId);
         assertEquals(check.getName(), "test-validate");
-
-        client.agentClient().deregisterCheck(checkId);
     }
 
     @Test
     public void shouldRegisterNodeTtlCheck() throws InterruptedException, MalformedURLException {
-        Consul client = Consul.builder().build();
         String checkId = UUID.randomUUID().toString();
 
         client.agentClient().registerCheck(checkId, "test-validate", 30);
@@ -298,8 +273,6 @@ public class AgentTests {
 
         assertEquals(check.getCheckId(), checkId);
         assertEquals(check.getName(), "test-validate");
-
-        client.agentClient().deregisterCheck(checkId);
     }
 
 

--- a/src/test/java/com/orbitz/consul/BaseIntegrationTest.java
+++ b/src/test/java/com/orbitz/consul/BaseIntegrationTest.java
@@ -1,0 +1,31 @@
+package com.orbitz.consul;
+
+import com.google.common.net.HostAndPort;
+import com.pszymczyk.consul.ConsulProcess;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import static com.pszymczyk.consul.ConsulStarterBuilder.consulStarter;
+
+public abstract class BaseIntegrationTest {
+
+    protected static ConsulProcess consul;
+    protected static Consul client;
+
+    @BeforeClass
+    public static void beforeClass() {
+        consul = consulStarter().build().start();
+        client = Consul.builder().withHostAndPort(HostAndPort.fromParts("localhost", consul.getHttpPort())).build();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        consul.close();
+    }
+
+    @Before
+    public void beforeTest() {
+        consul.reset();
+    }
+}

--- a/src/test/java/com/orbitz/consul/CatalogTests.java
+++ b/src/test/java/com/orbitz/consul/CatalogTests.java
@@ -18,11 +18,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class CatalogTests {
+public class CatalogTests extends BaseIntegrationTest {
 
     @Test
     public void shouldGetNodes() throws UnknownHostException {
-        Consul client = Consul.builder().build();
         CatalogClient catalogClient = client.catalogClient();
 
         assertFalse(catalogClient.getNodes().getResponse().isEmpty());
@@ -30,7 +29,6 @@ public class CatalogTests {
 
     @Test
     public void shouldGetNodesByDatacenter() throws UnknownHostException {
-        Consul client = Consul.builder().build();
         CatalogClient catalogClient = client.catalogClient();
 
         assertFalse(catalogClient.getNodes(ImmutableCatalogOptions.builder().datacenter("dc1").build()).getResponse().isEmpty());
@@ -38,7 +36,6 @@ public class CatalogTests {
 
     @Test
     public void shouldGetNodesByDatacenterBlock() throws UnknownHostException {
-        Consul client = Consul.builder().build();
         CatalogClient catalogClient = client.catalogClient();
 
         long start = System.currentTimeMillis();
@@ -52,7 +49,6 @@ public class CatalogTests {
 
     @Test
     public void shouldGetDatacenters() throws UnknownHostException {
-        Consul client = Consul.builder().build();
         CatalogClient catalogClient = client.catalogClient();
         List<String> datacenters = catalogClient.getDatacenters();
 
@@ -62,7 +58,6 @@ public class CatalogTests {
 
     @Test
     public void shouldGetServices() throws Exception {
-        Consul client = Consul.builder().build();
         CatalogClient catalogClient = client.catalogClient();
         ConsulResponse<Map<String, List<String>>> services = catalogClient.getServices();
 
@@ -71,7 +66,6 @@ public class CatalogTests {
 
     @Test
     public void shouldGetService() throws Exception {
-        Consul client = Consul.builder().build();
         CatalogClient catalogClient = client.catalogClient();
         ConsulResponse<List<CatalogService>> services = catalogClient.getService("consul");
 
@@ -80,7 +74,6 @@ public class CatalogTests {
 
     @Test
     public void shouldGetNode() throws Exception {
-        Consul client = Consul.builder().build();
         CatalogClient catalogClient = client.catalogClient();
         ConsulResponse<CatalogNode> node = catalogClient.getNode(catalogClient.getNodes()
                 .getResponse().iterator().next().getNode());
@@ -90,7 +83,6 @@ public class CatalogTests {
 
     @Test
     public void shouldGetTaggedAddressesForNodesLists() throws UnknownHostException {
-        Consul client = Consul.builder().build();
         CatalogClient catalogClient = client.catalogClient();
 
         final List<Node> nodesResp = catalogClient.getNodes().getResponse();
@@ -103,7 +95,6 @@ public class CatalogTests {
 
     @Test
     public void shouldGetTaggedAddressesForNode() throws UnknownHostException {
-        Consul client = Consul.builder().build();
         CatalogClient catalogClient = client.catalogClient();
 
         final List<Node> nodesResp = catalogClient.getNodes().getResponse();

--- a/src/test/java/com/orbitz/consul/EventTests.java
+++ b/src/test/java/com/orbitz/consul/EventTests.java
@@ -7,11 +7,10 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class EventTests {
+public class EventTests extends BaseIntegrationTest {
 
     @Test
     public void shouldFire() throws InterruptedException {
-        Consul client = Consul.builder().build();
         EventClient eventClient = client.eventClient();
 
         String name = RandomStringUtils.random(10);
@@ -32,7 +31,6 @@ public class EventTests {
 
     @Test
     public void shouldFireWithPayload() throws InterruptedException {
-        Consul client = Consul.builder().build();
         EventClient eventClient = client.eventClient();
 
         String payload = RandomStringUtils.randomAlphabetic(20);

--- a/src/test/java/com/orbitz/consul/HealthTests.java
+++ b/src/test/java/com/orbitz/consul/HealthTests.java
@@ -1,5 +1,6 @@
 package com.orbitz.consul;
 
+import com.google.common.net.HostAndPort;
 import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.model.State;
 import com.orbitz.consul.model.agent.ImmutableRegistration;
@@ -15,20 +16,20 @@ import java.net.UnknownHostException;
 import java.util.List;
 import java.util.UUID;
 
+import static com.orbitz.consul.Consul.builder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class HealthTests {
+public class HealthTests extends BaseIntegrationTest {
     @Test
     public void shouldFetchPassingNode() throws UnknownHostException, NotRegisteredException {
-        Consul client = Consul.builder().build();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
         client.agentClient().register(8080, 20L, serviceName, serviceId);
         client.agentClient().pass(serviceId);
 
-        Consul client2 = Consul.newClient();
+        Consul client2 = builder().withHostAndPort(HostAndPort.fromParts("localhost", consul.getHttpPort())).build();
         String serviceId2 = UUID.randomUUID().toString();
 
         client2.agentClient().register(8080, 20L, serviceName, serviceId2);
@@ -44,7 +45,6 @@ public class HealthTests {
 
     @Test
     public void shouldFetchNode() throws UnknownHostException, NotRegisteredException {
-        Consul client = Consul.builder().build();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
@@ -59,7 +59,6 @@ public class HealthTests {
 
     @Test
     public void shouldFetchNodeDatacenter() throws UnknownHostException, NotRegisteredException {
-        Consul client = Consul.builder().build();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
@@ -75,7 +74,6 @@ public class HealthTests {
 
     @Test
     public void shouldFetchNodeBlock() throws UnknownHostException, NotRegisteredException {
-        Consul client = Consul.builder().build();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
@@ -92,7 +90,6 @@ public class HealthTests {
 
     @Test
     public void shouldFetchChecksForServiceBlock() throws UnknownHostException, NotRegisteredException {
-        Consul client = Consul.builder().build();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
@@ -126,7 +123,6 @@ public class HealthTests {
 
     @Test
     public void shouldFetchByState() throws UnknownHostException, NotRegisteredException {
-        Consul client = Consul.builder().build();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 

--- a/src/test/java/com/orbitz/consul/KeyValueTests.java
+++ b/src/test/java/com/orbitz/consul/KeyValueTests.java
@@ -21,11 +21,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class KeyValueTests {
+public class KeyValueTests extends BaseIntegrationTest {
 
     @Test
     public void shouldPutAndReceiveString() throws UnknownHostException {
-        Consul client = Consul.builder().build();
         KeyValueClient keyValueClient = client.keyValueClient();
         String key = UUID.randomUUID().toString();
         String value = UUID.randomUUID().toString();
@@ -36,7 +35,6 @@ public class KeyValueTests {
 
     @Test
     public void shouldPutAndReceiveValue() throws UnknownHostException {
-        Consul client = Consul.builder().build();
         KeyValueClient keyValueClient = client.keyValueClient();
         String key = UUID.randomUUID().toString();
         String value = UUID.randomUUID().toString();
@@ -45,13 +43,11 @@ public class KeyValueTests {
         Value received = keyValueClient.getValue(key).get();
         assertEquals(value, received.getValueAsString().get());
         assertEquals(0L, received.getFlags());
-        keyValueClient.deleteKey(key);
 
     }
 
     @Test
     public void shouldPutAndReceiveWithFlags() throws UnknownHostException {
-        Consul client = Consul.builder().build();
         KeyValueClient keyValueClient = client.keyValueClient();
         String key = UUID.randomUUID().toString();
         String value = UUID.randomUUID().toString();
@@ -61,14 +57,12 @@ public class KeyValueTests {
         Value received = keyValueClient.getValue(key).get();
         assertEquals(value, received.getValueAsString().get());
         assertEquals(flags, received.getFlags());
-        keyValueClient.deleteKey(key);
 
     }
 
     @Test
     public void putNullValue() {
 
-        Consul client = Consul.builder().build();
         KeyValueClient keyValueClient = client.keyValueClient();
         String key = UUID.randomUUID().toString();
 
@@ -76,13 +70,10 @@ public class KeyValueTests {
 
         Value received = keyValueClient.getValue(key).get();
         assertFalse(received.getValue().isPresent());
-
-        keyValueClient.deleteKey(key);
     }
 
     @Test
     public void shouldPutAndReceiveStrings() throws UnknownHostException {
-        Consul client = Consul.builder().build();
         KeyValueClient keyValueClient = client.keyValueClient();
         String key = UUID.randomUUID().toString();
         String key2 = key + "/" + UUID.randomUUID().toString();
@@ -97,15 +88,10 @@ public class KeyValueTests {
                 add(value2);
             }
         }, new HashSet<String>(keyValueClient.getValuesAsString(key)));
-
-        keyValueClient.deleteKey(key);
-        keyValueClient.deleteKey(key2);
-
     }
 
     @Test
     public void shouldDelete() throws Exception {
-        Consul client = Consul.builder().build();
         KeyValueClient keyValueClient = client.keyValueClient();
         String key = UUID.randomUUID().toString();
         final String value = UUID.randomUUID().toString();
@@ -123,7 +109,6 @@ public class KeyValueTests {
     @Test
     public void shouldDeleteRecursively() throws Exception {
 
-        Consul client = Consul.builder().build();
         KeyValueClient keyValueClient = client.keyValueClient();
         String key = UUID.randomUUID().toString();
         String childKEY = key + "/" + UUID.randomUUID().toString();
@@ -144,7 +129,6 @@ public class KeyValueTests {
 
     @Test
     public void acquireAndReleaseLock() throws Exception {
-        Consul client = Consul.builder().build();
         KeyValueClient keyValueClient = client.keyValueClient();
         SessionClient sessionClient = client.sessionClient();
         String key = UUID.randomUUID().toString();
@@ -165,7 +149,6 @@ public class KeyValueTests {
 
     @Test
     public void testGetSession() throws Exception {
-        Consul client = Consul.builder().build();
         KeyValueClient keyValueClient = client.keyValueClient();
         SessionClient sessionClient = client.sessionClient();
 
@@ -183,14 +166,12 @@ public class KeyValueTests {
         assertTrue(keyValueClient.acquireLock(key, sessionValue, sessionId));
         assertTrue(keyValueClient.acquireLock(key, sessionValue, sessionId)); // No ideas why there was an assertFalse
         assertEquals(sessionId, keyValueClient.getSession(key).get());
-        keyValueClient.deleteKey(key);
 
     }
 
     @Test
     public void testGetKeys() throws Exception {
-        Consul consul = Consul.builder().build();
-        KeyValueClient kvClient = consul.keyValueClient();
+        KeyValueClient kvClient = client.keyValueClient();
         String testString = "Hello World!";
         String key = "my_key";
         kvClient.putValue(key, testString);
@@ -203,7 +184,6 @@ public class KeyValueTests {
 
     @Test
     public void testAcquireLock() throws Exception {
-        Consul client = Consul.builder().build();
         KeyValueClient keyValueClient = client.keyValueClient();
         SessionClient sessionClient = client.sessionClient();
 
@@ -234,12 +214,10 @@ public class KeyValueTests {
         assertFalse(keyValueClient.acquireLock(key, sessionValue, sessionId));
         assertEquals(sessionId2, keyValueClient.getSession(key).get());
 
-        keyValueClient.deleteKey(key);
     }
 
     @Test
     public void testGetValuesAsync() throws InterruptedException {
-        Consul client = Consul.builder().build();
         KeyValueClient keyValueClient = client.keyValueClient();
         String key = UUID.randomUUID().toString();
         String value = UUID.randomUUID().toString();
@@ -268,7 +246,6 @@ public class KeyValueTests {
 
     @Test
     public void testGetValueNotFoundAsync() throws InterruptedException {
-        Consul client = Consul.builder().build();
         KeyValueClient keyValueClient = client.keyValueClient();
         String key = UUID.randomUUID().toString();
 

--- a/src/test/java/com/orbitz/consul/SessionClientTest.java
+++ b/src/test/java/com/orbitz/consul/SessionClientTest.java
@@ -4,7 +4,6 @@ import com.orbitz.consul.model.session.ImmutableSession;
 import com.orbitz.consul.model.session.Session;
 import com.orbitz.consul.model.session.SessionCreatedResponse;
 import com.orbitz.consul.model.session.SessionInfo;
-import org.junit.After;
 import org.junit.Test;
 
 import java.util.List;
@@ -15,45 +14,28 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class SessionClientTest {
-
-    @After
-    public void cleanUp() {
-        SessionClient sessionClient = Consul.newClient().sessionClient();
-        List<SessionInfo> result = sessionClient.listSessions();
-
-        for(SessionInfo info : result) {
-            sessionClient.destroySession(info.getId());
-        }
-    }
+public class SessionClientTest extends BaseIntegrationTest {
 
     @Test
     public void testCreateAndDestroySession() throws Exception {
-        Consul client = Consul.builder().build();
         SessionClient sessionClient = client.sessionClient();
         final Session value = ImmutableSession.builder().name("session_" + UUID.randomUUID().toString()).build();
 
         SessionCreatedResponse session = sessionClient.createSession(value);
 
         assertNotNull(session);
-
-        sessionClient.destroySession(session.getId());
     }
 
     @Test
     public void testCreateEmptySession() throws Exception {
-        Consul client = Consul.builder().build();
         SessionClient sessionClient = client.sessionClient();
         SessionCreatedResponse session = sessionClient.createSession(ImmutableSession.builder().build());
 
         assertNotNull(session);
-
-        sessionClient.destroySession(session.getId());
     }
 
     @Test(expected = ConsulException.class)
     public void testRenewSession() throws Exception {
-        Consul client = Consul.builder().build();
         SessionClient sessionClient = client.sessionClient();
         final Session value = ImmutableSession.builder().name("session_" + UUID.randomUUID().toString()).build();
 
@@ -64,13 +46,10 @@ public class SessionClientTest {
         SessionInfo info = sessionClient.renewSession(session.getId()).get();
 
         assertEquals(session.getId(), info.getId());
-
-        sessionClient.renewSession("doesn't exist!");
     }
 
     @Test
     public void testGetSessionInfo() throws Exception {
-        Consul client = Consul.builder().build();
         KeyValueClient keyValueClient = client.keyValueClient();
         SessionClient sessionClient = client.sessionClient();
         String key = UUID.randomUUID().toString();
@@ -89,7 +68,6 @@ public class SessionClientTest {
 
     @Test
     public void testListSessions() throws Exception {
-        Consul client = Consul.builder().build();
         KeyValueClient keyValueClient = client.keyValueClient();
         SessionClient sessionClient = client.sessionClient();
         String key = UUID.randomUUID().toString();

--- a/src/test/java/com/orbitz/consul/StatusClientTests.java
+++ b/src/test/java/com/orbitz/consul/StatusClientTests.java
@@ -19,7 +19,7 @@ import java.util.logging.Logger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class StatusClientTests {
+public class StatusClientTests extends BaseIntegrationTest {
 
     private static Set<InetAddress> ips = new HashSet<InetAddress>();
 
@@ -53,32 +53,31 @@ public class StatusClientTests {
     }
 
     public static final String IP_PORT_DELIM = ":";
-    public static final String CONSUL_PORT = "8300";
 
     public String getIp(String ipAndPort) {
         return ipAndPort.substring(0, ipAndPort.indexOf(IP_PORT_DELIM));
     }
 
-    public String getPort(String ipAndPort) {
-        return ipAndPort.substring(ipAndPort.indexOf(IP_PORT_DELIM) + 1);
+    public int getPort(String ipAndPort) {
+        return Integer.valueOf(ipAndPort.substring(ipAndPort.indexOf(IP_PORT_DELIM) + 1));
     }
 
     public void assertLocalIpAndCorrectPort(String ipAndPort) throws UnknownHostException {
         String ip = getIp(ipAndPort);
-        String port = getPort(ipAndPort);
+        int port = getPort(ipAndPort);
         assertTrue(isLocalIp(ip));
-        assertEquals(CONSUL_PORT, port);
+        assertEquals(consul.getServerPort(), port);
     }
 
     @Test
     public void shouldGetLeader() throws UnknownHostException {
-        String ipAndPort = Consul.newClient().statusClient().getLeader();
+        String ipAndPort = client.statusClient().getLeader();
         assertLocalIpAndCorrectPort(ipAndPort);
     }
 
     @Test
     public void shouldGetPeers() throws UnknownHostException {
-        List<String> peers = Consul.newClient().statusClient().getPeers();
+        List<String> peers = client.statusClient().getPeers();
         for (String ipAndPort : peers) {
             assertLocalIpAndCorrectPort(ipAndPort);
         }

--- a/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
@@ -2,15 +2,13 @@ package com.orbitz.consul.cache;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
-import com.orbitz.consul.Consul;
+import com.orbitz.consul.BaseIntegrationTest;
 import com.orbitz.consul.HealthClient;
 import com.orbitz.consul.KeyValueClient;
 import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.model.State;
 import com.orbitz.consul.model.agent.Agent;
-import com.orbitz.consul.model.agent.Check;
 import com.orbitz.consul.model.health.HealthCheck;
-import com.orbitz.consul.model.health.Service;
 import com.orbitz.consul.model.health.ServiceHealth;
 import com.orbitz.consul.model.kv.Value;
 import org.junit.Test;
@@ -29,12 +27,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
-public class ConsulCacheTest {
-
+public class ConsulCacheTest extends BaseIntegrationTest {
 
     @Test
     public void nodeCacheHealthCheckTest() throws Exception {
-        Consul client = Consul.newClient();
         HealthClient healthClient = client.healthClient();
         String checkName = UUID.randomUUID().toString();
         String checkId = UUID.randomUUID().toString();
@@ -60,7 +56,6 @@ public class ConsulCacheTest {
 
     @Test
     public void nodeCacheServicePassingTest() throws Exception {
-        Consul client = Consul.newClient();
         HealthClient healthClient = client.healthClient();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
@@ -89,7 +84,6 @@ public class ConsulCacheTest {
 
     @Test
     public void testServicesAreUniqueByID() throws Exception {
-        Consul client = Consul.newClient();
         HealthClient healthClient = client.healthClient();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
@@ -124,8 +118,7 @@ public class ConsulCacheTest {
     @Test
     public void nodeCacheKvTest() throws Exception {
 
-        Consul consul = Consul.newClient();
-        KeyValueClient kvClient = consul.keyValueClient();
+        KeyValueClient kvClient = client.keyValueClient();
         String root = UUID.randomUUID().toString();
 
         for (int i = 0; i < 5; i++) {
@@ -169,8 +162,7 @@ public class ConsulCacheTest {
 
     @Test
     public void testListeners() throws Exception {
-        Consul consul = Consul.newClient();
-        KeyValueClient kvClient = consul.keyValueClient();
+        KeyValueClient kvClient = client.keyValueClient();
         String root = UUID.randomUUID().toString();
 
         KVCache nc = KVCache.newCache(
@@ -214,8 +206,7 @@ public class ConsulCacheTest {
 
     @Test
     public void testLateListenersGetValues() throws Exception {
-        Consul consul = Consul.newClient();
-        KeyValueClient kvClient = consul.keyValueClient();
+        KeyValueClient kvClient = client.keyValueClient();
         String root = UUID.randomUUID().toString();
 
         KVCache nc = KVCache.newCache(
@@ -255,8 +246,7 @@ public class ConsulCacheTest {
 
     @Test(expected = IllegalStateException.class)
     public void testLifeCycleDoubleStart() throws Exception {
-        Consul consul = Consul.newClient();
-        KeyValueClient kvClient = consul.keyValueClient();
+        KeyValueClient kvClient = client.keyValueClient();
         String root = UUID.randomUUID().toString();
 
         KVCache nc = KVCache.newCache(
@@ -277,8 +267,7 @@ public class ConsulCacheTest {
 
     @Test
     public void testLifeCycle() throws Exception {
-        Consul consul = Consul.newClient();
-        KeyValueClient kvClient = consul.keyValueClient();
+        KeyValueClient kvClient = client.keyValueClient();
         String root = UUID.randomUUID().toString();
 
         KVCache nc = KVCache.newCache(
@@ -322,11 +311,11 @@ public class ConsulCacheTest {
         kvClient.deleteKeys(root);
 
     }
-    
+
     /**
      * Test that if Consul for some reason returns a duplicate service or keyvalue entry
      * that we recover gracefully by taking the first value, ignoring duplicates, and warning
-     * user of the condition 
+     * user of the condition
      */
     @Test
     public void testDuplicateServicesDontCauseFailure() {
@@ -338,7 +327,7 @@ public class ConsulCacheTest {
         };
         final List<Value> response = Arrays.asList(Mockito.mock(Value.class), Mockito.mock(Value.class));
         final ConsulCache<String, Value> consulCache = new ConsulCache<>(keyExtractor, null);
-        final ConsulResponse<List<Value>> consulResponse = new ConsulResponse<>(response, 0, false, BigInteger.ONE); 
+        final ConsulResponse<List<Value>> consulResponse = new ConsulResponse<>(response, 0, false, BigInteger.ONE);
         final ImmutableMap<String, Value> map = consulCache.convertToMap(consulResponse);
         assertNotNull(map);
         // Second copy has been weeded out

--- a/src/test/java/com/orbitz/consul/util/CustomBuilderTest.java
+++ b/src/test/java/com/orbitz/consul/util/CustomBuilderTest.java
@@ -1,5 +1,7 @@
 package com.orbitz.consul.util;
 
+import com.google.common.net.HostAndPort;
+import com.orbitz.consul.BaseIntegrationTest;
 import com.orbitz.consul.Consul;
 import com.orbitz.consul.model.agent.Agent;
 import org.junit.Test;
@@ -9,11 +11,12 @@ import java.net.UnknownHostException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-public class CustomBuilderTest {
+public class CustomBuilderTest extends BaseIntegrationTest{
 
     @Test
     public void shouldConnectWithCustomTimeouts() throws UnknownHostException {
         Consul client = Consul.builder()
+                .withHostAndPort(HostAndPort.fromParts("localhost", consul.getHttpPort()))
                 .withConnectTimeoutMillis(10000)
                 .withReadTimeoutMillis(3600000)
                 .withWriteTimeoutMillis(900)

--- a/src/test/java/com/orbitz/consul/util/LeaderElectionUtilTest.java
+++ b/src/test/java/com/orbitz/consul/util/LeaderElectionUtilTest.java
@@ -1,5 +1,6 @@
 package com.orbitz.consul.util;
 
+import com.orbitz.consul.BaseIntegrationTest;
 import com.orbitz.consul.Consul;
 import org.junit.Test;
 
@@ -7,11 +8,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class LeaderElectionUtilTest {
+public class LeaderElectionUtilTest extends BaseIntegrationTest {
 
     @Test
     public void testGetLeaderInfoForService() throws Exception {
-        Consul client = Consul.newClient();
         LeaderElectionUtil leutil = new LeaderElectionUtil(client);
         final String serviceName = "myservice100";
         final String serviceInfo = "serviceinfo";


### PR DESCRIPTION
Hi

This PR introduces new way of launch Consul Agent in tests. I propose using my open source tool - embedded-consul instaed of downloading Consul by travis. It's better solution because tests passing out of Travis enviroment. Also all data persisted in Consul (checks, services etc) are removed after each test so you do not have to remove it manually. 

Regards
Pawel