### PR TITLE
Add Catalog Cache

### DIFF
--- a/src/main/java/com/orbitz/consul/CatalogClient.java
+++ b/src/main/java/com/orbitz/consul/CatalogClient.java
@@ -1,5 +1,6 @@
 package com.orbitz.consul;
 
+import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.model.catalog.CatalogNode;
 import com.orbitz.consul.model.catalog.CatalogService;
@@ -144,6 +145,33 @@ public class CatalogClient {
      */
     public ConsulResponse<Map<String, List<String>>> getServices(CatalogOptions catalogOptions, QueryOptions queryOptions) {
         return extractConsulResponse(api.getServices(Options.from(catalogOptions, queryOptions)));
+    }
+
+    /**
+     * Retrieves a single service.
+     *
+     * GET /v1/catalog/service/{service}
+     *
+     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing
+     * {@link com.orbitz.consul.model.catalog.CatalogService} objects.
+     */
+
+    /**
+     * Asynchronously retrieves a single service
+     *
+     * GET /v1/catalog/service/{service}
+     *
+     * @param service      The service to query.
+     * @param catalogOptions Catalog specific options to use.
+     * @param queryOptions The Query Options to use.
+     * @param callback       Callback implemented by callee to handle results.
+     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     */
+    public void getService(String service,
+                           CatalogOptions catalogOptions,
+                           QueryOptions queryOptions,
+                           ConsulResponseCallback<List<CatalogService>> callback) {
+        extractConsulResponse(api.getService(service, Options.from(catalogOptions, queryOptions)), callback);
     }
 
     /**

--- a/src/main/java/com/orbitz/consul/CatalogClient.java
+++ b/src/main/java/com/orbitz/consul/CatalogClient.java
@@ -179,6 +179,7 @@ public class CatalogClient {
      *
      * GET /v1/catalog/service/{service}
      *
+     * @param service      The service to query.
      * @return A {@link com.orbitz.consul.model.ConsulResponse} containing
      * {@link com.orbitz.consul.model.catalog.CatalogService} objects.
      */

--- a/src/main/java/com/orbitz/consul/cache/CatalogServiceCache.java
+++ b/src/main/java/com/orbitz/consul/cache/CatalogServiceCache.java
@@ -1,0 +1,41 @@
+package com.orbitz.consul.cache;
+
+import com.google.common.base.Function;
+import com.orbitz.consul.CatalogClient;
+import com.orbitz.consul.async.ConsulResponseCallback;
+import com.orbitz.consul.model.catalog.CatalogService;
+import com.orbitz.consul.option.CatalogOptions;
+
+import java.math.BigInteger;
+import java.util.List;
+
+public class CatalogServiceCache extends ConsulCache<CatalogServiceKey, CatalogService> {
+
+    CatalogServiceCache(Function<CatalogService, CatalogServiceKey> keyConversion, CallbackConsumer<CatalogService> callbackConsumer) {
+        super(keyConversion, callbackConsumer);
+    }
+
+    public static CatalogServiceCache newCache(final CatalogClient catalogClient,
+                                               final String serviceName,
+                                               final CatalogOptions catalogOptions,
+                                               final int watchSeconds) {
+        Function<CatalogService, CatalogServiceKey> keyExtractor = new Function<CatalogService, CatalogServiceKey>() {
+            @Override
+            public CatalogServiceKey apply(CatalogService input) {
+                return CatalogServiceKey.fromCatalogService(input);
+            }
+        };
+
+        CallbackConsumer<CatalogService> callbackConsumer = new CallbackConsumer<CatalogService>() {
+            @Override
+            public void consume(BigInteger index, ConsulResponseCallback<List<CatalogService>> callback) {
+                catalogClient.getService(serviceName, catalogOptions, watchParams(index, watchSeconds), callback);
+            }
+        };
+        return new CatalogServiceCache(keyExtractor, callbackConsumer);
+    }
+
+    public static CatalogServiceCache newCache(final CatalogClient catalogClient, final String serviceName) {
+        return newCache(catalogClient, serviceName, CatalogOptions.BLANK, 10);
+    }
+}

--- a/src/main/java/com/orbitz/consul/cache/CatalogServiceKey.java
+++ b/src/main/java/com/orbitz/consul/cache/CatalogServiceKey.java
@@ -1,0 +1,34 @@
+package com.orbitz.consul.cache;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.orbitz.consul.model.catalog.CatalogService;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class CatalogServiceKey {
+
+    public abstract String getServiceId();
+
+    public abstract String getHost();
+
+    public abstract Integer getPort();
+
+    public static CatalogServiceKey fromCatalogService(CatalogService service) {
+
+        return CatalogServiceKey.of(
+                service.getServiceId()
+                , service.getAddress()
+                , service.getServicePort()
+        );
+    }
+
+    public static CatalogServiceKey of(String serviceId, String host, int port) {
+        return ImmutableCatalogServiceKey.builder()
+                .serviceId(serviceId)
+                .host(host)
+                .port(port)
+                .build();
+    }
+}

--- a/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
@@ -25,7 +25,12 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class ConsulCacheTest extends BaseIntegrationTest {
 

--- a/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
@@ -3,11 +3,13 @@ package com.orbitz.consul.cache;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.orbitz.consul.BaseIntegrationTest;
+import com.orbitz.consul.CatalogClient;
 import com.orbitz.consul.HealthClient;
 import com.orbitz.consul.KeyValueClient;
 import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.model.State;
 import com.orbitz.consul.model.agent.Agent;
+import com.orbitz.consul.model.catalog.CatalogService;
 import com.orbitz.consul.model.health.HealthCheck;
 import com.orbitz.consul.model.health.ServiceHealth;
 import com.orbitz.consul.model.kv.Value;
@@ -17,15 +19,13 @@ import org.mockito.Mockito;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class ConsulCacheTest extends BaseIntegrationTest {
 
@@ -333,4 +333,80 @@ public class ConsulCacheTest extends BaseIntegrationTest {
         // Second copy has been weeded out
         assertEquals(1, map.size());
     }
+
+    @Test
+    public void nodeCacheServiceDeregistereTest() throws Exception {
+        CatalogClient catalogClient = client.catalogClient();
+        String serviceName = UUID.randomUUID().toString();
+        String serviceId = UUID.randomUUID().toString();
+
+        CatalogServiceCache svCatalogCache = CatalogServiceCache.newCache(catalogClient, serviceName);
+        svCatalogCache.start();
+        svCatalogCache.awaitInitialized(3, TimeUnit.SECONDS);
+
+        client.agentClient().register(8080, 20L, serviceName, serviceId);
+        Agent agent = client.agentClient().getAgent();
+        Thread.sleep(100);
+
+        CatalogServiceKey serviceKey = CatalogServiceKey.of(serviceId, agent.getConfig().getAdvertiseAddr(), 8080);
+        CatalogService service = svCatalogCache.getMap().get(serviceKey);
+        assertEquals(serviceId, service.getServiceId());
+
+        client.agentClient().deregister(serviceId);
+        Thread.sleep(100);
+
+        service = svCatalogCache.getMap().get(serviceKey);
+        assertNull(service);
+
+    }
+
+
+    @Test
+    public void testCatalogCacheListeners() throws Exception {
+        CatalogClient catalogClient = client.catalogClient();
+        String serviceName = UUID.randomUUID().toString();
+        String serviceId = UUID.randomUUID().toString();
+
+        CatalogServiceCache svCatalogCache = CatalogServiceCache.newCache(catalogClient, serviceName);
+
+        final Map<CatalogServiceKey, CatalogService> values = new HashMap<>();
+        svCatalogCache.addListener(new ConsulCache.Listener<CatalogServiceKey, CatalogService>() {
+            @Override
+            public void notify(Map<CatalogServiceKey, CatalogService> newValues) {
+                values.putAll(newValues);
+            }
+        });
+
+        svCatalogCache.start();
+        if (!svCatalogCache.awaitInitialized(3, TimeUnit.SECONDS)) {
+            fail("cache initialization failed");
+        }
+
+        // Register new service and check it triggers the listener to react
+        client.agentClient().register(8080, 20L, serviceName, serviceId);
+        Agent agent = client.agentClient().getAgent();
+        Thread.sleep(100);
+
+        CatalogServiceKey serviceKey = CatalogServiceKey.of(serviceId, agent.getConfig().getAdvertiseAddr(), 8080);
+        assertTrue(values.containsKey(serviceKey));
+
+        // Register a second service and check it triggers the listener to react
+        values.clear();
+        String serviceId2 = UUID.randomUUID().toString();
+        client.agentClient().register(8080, 20L, serviceName, serviceId2);
+        Thread.sleep(100);
+
+        CatalogServiceKey serviceKey2 = CatalogServiceKey.of(serviceId2, agent.getConfig().getAdvertiseAddr(), 8080);
+        assertTrue(values.containsKey(serviceKey2));
+
+        // Derregister service and check listener is triggered without this value.
+        values.clear();
+        client.agentClient().deregister(serviceId);
+        Thread.sleep(100);
+
+        assertFalse(values.containsKey(serviceKey));
+        assertTrue(values.containsKey(serviceKey2));
+
+    }
+
 }


### PR DESCRIPTION
For our use case, it is very interesting the ServiceHealthCache. We have a listener to know when a service becomes unhealthy so we stop using it.
But we were missing the case when a service is stopped and is deregistered from Consul. In that case ServiceHealthCache makes no notification.

I've just made the equivalent of your HealthCache for the Catalog of services.
We'll start to use it, but I thought it belongs more to this client instead of the code in our side