### PR TITLE
set index and lastContact in ConsulResponse to 0 instead of -1 if header's aren't present

### DIFF
--- a/src/main/java/com/orbitz/consul/util/Http.java
+++ b/src/main/java/com/orbitz/consul/util/Http.java
@@ -91,8 +91,8 @@ public class Http {
         String lastContactHeaderValue = headers.get("X-Consul-Lastcontact");
         String knownLeaderHeaderValue = headers.get("X-Consul-Knownleader");
 
-        BigInteger index = indexHeaderValue == null ? new BigInteger("-1") : new BigInteger(indexHeaderValue);
-        long lastContact = lastContactHeaderValue == null ? -1 : Long.valueOf(lastContactHeaderValue);
+        BigInteger index = indexHeaderValue == null ? new BigInteger("0") : new BigInteger(indexHeaderValue);
+        long lastContact = lastContactHeaderValue == null ? 0 : Long.valueOf(lastContactHeaderValue);
         boolean knownLeader = knownLeaderHeaderValue == null ? false : Boolean.valueOf(knownLeaderHeaderValue);
 
         ConsulResponse<T> consulResponse = new ConsulResponse<>(response.body(), lastContact, knownLeader, index);


### PR DESCRIPTION
Unfortunately, my previous PR (#153) introduced some unwanted behaviour. 
Consider the blocking query example from the Readme. Let's say there's currently now consul leader. Then onComplete will be called at once and the index-property of the callback object will be set to -1. 

Consecutive query attemps (in the watch-method) will then set -1 as the index in the QueryOptions. 
Consul doesn't accept -1 as an index value an will respond accordingly with status code 400, so even when there is a newly elected cluster leader, we'll be unable to successfully execute the blocking query or read a valid index value.

Therefore I suggest to return 0 as an index value instead of -1 if the respective headers are not present in the response. This would break backwards compatibility though.



