### PR TITLE
Check for error responses when using callbacks

### DIFF
--- a/src/main/java/com/orbitz/consul/util/Http.java
+++ b/src/main/java/com/orbitz/consul/util/Http.java
@@ -60,7 +60,11 @@ public class Http {
         call.enqueue(new retrofit2.Callback<T>() {
             @Override
             public void onResponse(Call<T> call, Response<T> response) {
-                callback.onComplete(consulResponse(response));
+                if (response.isSuccessful()) {
+                    callback.onComplete(consulResponse(response));
+                } else {
+                    callback.onFailure(new ConsulException(response.code(), response));
+                }
             }
 
             @Override
@@ -75,7 +79,11 @@ public class Http {
 
             @Override
             public void onResponse(Call<T> call, Response<T> response) {
-                callback.onResponse(response.body());
+                if (response.isSuccessful()) {
+                    callback.onResponse(response.body());
+                } else {
+                    callback.onFailure(new ConsulException(response.code(), response));
+                }
             }
 
             @Override

--- a/src/test/java/com/orbitz/consul/KeyValueTests.java
+++ b/src/test/java/com/orbitz/consul/KeyValueTests.java
@@ -257,14 +257,12 @@ public class KeyValueTests extends BaseIntegrationTest {
 
             @Override
             public void onComplete(ConsulResponse<Optional<Value>> consulResponse) {
-
-                success.set(!consulResponse.getResponse().isPresent());
                 completed.countDown();
             }
 
             @Override
             public void onFailure(Throwable throwable) {
-                throwable.printStackTrace();
+                success.set(throwable instanceof ConsulException);;
                 completed.countDown();
             }
         });


### PR DESCRIPTION
Unlike the synchronous code path, the asynchronous response handlers do not check whether the call succeeded, so errors are ignored and inaccessible.