### PR TITLE
Build non-shaded jar as well as shaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Installation
 
 ### Note
 
-As of 0.11.X, the Consul JAR is now a shaded JAR, with most dependencies included. This was done because a number of issues being files were related to dependency conflicts. The JAR is a bit bigger, but the HTTP + JSON libraries are now internal to the JAR. Only Guava is still a transitive dependency.
+In 0.13.x, both shaded and non-shaded JARs are provided. The shaded JAR has a `shaded` classifier, while the non-shaded JAR has no classifier. Note that this is a change from 0.12 and 0.11.
+
+In 0.11.X and 0.12.x, the Consul JAR is a shaded JAR, with most dependencies included. This was done because a number of issues being files were related to dependency conflicts. The JAR is a bit bigger, but the HTTP + JSON libraries are now internal to the JAR. Only Guava is still a transitive dependency.
 
 ### Bintray:
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.orbitz.consul</groupId>
     <artifactId>consul-client</artifactId>
     <packaging>jar</packaging>
-    <version>0.12.8</version>
+    <version>0.13.0</version>
     <name>consul-client</name>
     <url>http://maven.apache.org</url>
     <description>Consul Client for Java</description>

--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,8 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>shaded</shadedClassifierName>
                             <artifactSet>
                                 <excludes>
                                     <exclude>org.slf4j:slf4j-api</exclude>


### PR DESCRIPTION
Hi there, thanks for this very useful lib!

We are having a bit of trouble using it, unfortunately, because it's shaded-only. While shading a JAR can be useful to solve some problems, it can also cause different issues to crop up.

For example, when using the shaded JAR with `sbt-assembly`, you get conflicting files:

```
[error] (*:assembly) deduplicate: different file contents found in the following:
[error] /home/dvangeest/.ivy2/cache/com.fasterxml.jackson.core/jackson-annotations/bundles/jackson-annotations-2.6.0.jar:META-INF/maven/com.fasterxml.jackson.core/jackson-annotations/pom.properties
[error] /home/dvangeest/.ivy2/cache/com.orbitz.consul/consul-client/jars/consul-client-0.12.3.jar:META-INF/maven/com.fasterxml.jackson.core/jackson-annotations/pom.properties
[error] Total time: 19 s, completed 20-Sep-2016 10:54:39 AM
```

A simple solution to this is to allow the user to pick whether they want to use the shaded JAR or a non-shaded JAR. This PR tweaks the `maven-shade-plugin` config to build both a shaded and non-shaded JAR according to http://maven.apache.org/plugins/maven-shade-plugin/examples/attached-artifact.html.

This does mean that the default JAR is now un-shaded again, and to get the shaded JAR you need to put a `shaded` classifier on your dependency. While this is maybe a little annoying in the short-term, long-term it's closer to what people expect. That is, most people expect JARs to be un-shaded. Having a shaded JAR is an exception and should be treated as such.

Please let me know if I can do anything else to get this merged. Thanks!