### PR TITLE
Enable additional query options for caches

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableMap;
 import com.orbitz.consul.ConsulException;
 import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.ConsulResponse;
+import com.orbitz.consul.option.ImmutableQueryOptions;
 import com.orbitz.consul.option.QueryOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,6 +16,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
 /**
@@ -164,7 +166,20 @@ public class ConsulCache<K, V> {
         }
     }
 
-    protected static QueryOptions watchParams(BigInteger index, int blockSeconds) {
+    protected static QueryOptions watchParams(final BigInteger index, final int blockSeconds,
+                                              QueryOptions queryOptions) {
+        checkArgument(!queryOptions.getIndex().isPresent() && !queryOptions.getWait().isPresent(),
+                "Index and wait cannot be overridden");
+
+        return ImmutableQueryOptions.builder()
+                .from(watchDefaultParams(index, blockSeconds))
+                .token(queryOptions.getToken())
+                .consistencyMode(queryOptions.getConsistencyMode())
+                .near(queryOptions.getNear())
+                .build();
+    }
+
+    private static QueryOptions watchDefaultParams(final BigInteger index, final int blockSeconds) {
         if (index == null) {
             return QueryOptions.BLANK;
         } else {

--- a/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
+++ b/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
@@ -1,12 +1,11 @@
 package com.orbitz.consul.cache;
 
 import com.google.common.base.Function;
-import com.google.common.net.HostAndPort;
 import com.orbitz.consul.HealthClient;
 import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.health.HealthCheck;
-import com.orbitz.consul.model.health.ServiceHealth;
 import com.orbitz.consul.option.CatalogOptions;
+import com.orbitz.consul.option.QueryOptions;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -30,7 +29,8 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
             final HealthClient healthClient,
             final com.orbitz.consul.model.State state,
             final CatalogOptions catalogOptions,
-            final int watchSeconds) {
+            final int watchSeconds,
+            final QueryOptions queryOptions) {
         Function<HealthCheck, String> keyExtractor = new Function<HealthCheck, String>() {
             @Override
             public String apply(HealthCheck input) {
@@ -41,12 +41,21 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
         CallbackConsumer<HealthCheck> callbackConsumer = new CallbackConsumer<HealthCheck>() {
             @Override
             public void consume(BigInteger index, ConsulResponseCallback<List<HealthCheck>> callback) {
-                healthClient.getChecksByState(state, catalogOptions, watchParams(index, watchSeconds), callback);
+                QueryOptions params = watchParams(index, watchSeconds, queryOptions);
+                healthClient.getChecksByState(state, catalogOptions, params, callback);
             }
         };
 
         return new HealthCheckCache(keyExtractor, callbackConsumer);
 
+    }
+
+    public static HealthCheckCache newCache(
+            final HealthClient healthClient,
+            final com.orbitz.consul.model.State state,
+            final CatalogOptions catalogOptions,
+            final int watchSeconds) {
+        return newCache(healthClient, state, catalogOptions, watchSeconds, QueryOptions.BLANK);
     }
 
     public static HealthCheckCache newCache(final HealthClient healthClient, final com.orbitz.consul.model.State state) {

--- a/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
@@ -6,6 +6,7 @@ import com.orbitz.consul.HealthClient;
 import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.health.ServiceHealth;
 import com.orbitz.consul.option.CatalogOptions;
+import com.orbitz.consul.option.QueryOptions;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -31,7 +32,8 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
             final String serviceName,
             final boolean passing,
             final CatalogOptions catalogOptions,
-            final int watchSeconds) {
+            final int watchSeconds,
+            final QueryOptions queryOptions) {
         Function<ServiceHealth, ServiceHealthKey> keyExtractor = new Function<ServiceHealth, ServiceHealthKey>() {
             @Override
             public ServiceHealthKey apply(ServiceHealth input) {
@@ -42,20 +44,28 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
         CallbackConsumer<ServiceHealth> callbackConsumer = new CallbackConsumer<ServiceHealth>() {
             @Override
             public void consume(BigInteger index, ConsulResponseCallback<List<ServiceHealth>> callback) {
+                QueryOptions params = watchParams(index, watchSeconds, queryOptions);
                 if (passing) {
-                    healthClient.getHealthyServiceInstances(serviceName, catalogOptions, watchParams(index, watchSeconds), callback);
+                    healthClient.getHealthyServiceInstances(serviceName, catalogOptions, params, callback);
                 } else {
-                    healthClient.getAllServiceInstances(serviceName, catalogOptions, watchParams(index, watchSeconds), callback);
+                    healthClient.getAllServiceInstances(serviceName, catalogOptions, params, callback);
                 }
             }
         };
 
         return new ServiceHealthCache(keyExtractor, callbackConsumer);
+    }
 
+    public static ServiceHealthCache newCache(
+            final HealthClient healthClient,
+            final String serviceName,
+            final boolean passing,
+            final CatalogOptions catalogOptions,
+            final int watchSeconds) {
+        return newCache(healthClient, serviceName, passing, catalogOptions, watchSeconds, QueryOptions.BLANK);
     }
 
     public static ServiceHealthCache newCache(final HealthClient healthClient, final String serviceName) {
         return newCache(healthClient, serviceName, true, CatalogOptions.BLANK, 10);
     }
-
 }


### PR DESCRIPTION
Allow override of query options for caches (HealthCheck, ServiceHealth and
KeyValue). Consistency mode, token and near can now be specified for caches.