### PR TITLE
Support the new DeregisterCriticalServerAfter option in Consul 0.7

### DIFF
--- a/src/main/java/com/orbitz/consul/model/agent/Registration.java
+++ b/src/main/java/com/orbitz/consul/model/agent/Registration.java
@@ -71,6 +71,9 @@ public abstract class Registration {
         @JsonProperty("Notes")
         public abstract Optional<String> getNotes();
 
+        @JsonProperty("DeregisterCriticalServiceAfter")
+        public abstract Optional<String> getDeregisterCriticalServiceAfter();
+
         public static RegCheck ttl(long ttl) {
             return ImmutableRegCheck
                     .builder()


### PR DESCRIPTION
Sorry, I missed adding this to the `Registration` model in https://github.com/OrbitzWorldwide/consul-client/pull/165