### PR TITLE
Add node membership watch capabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,13 @@
             <artifactId>guava</artifactId>
             <version>19.0</version>
         </dependency>
+        <!-- this dependency is required to avoid javax.annotation.CheckReturnValue,
+         see https://github.com/google/guava/issues/2450 for more details -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>1.3.9</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>

--- a/src/main/java/com/orbitz/consul/CatalogClient.java
+++ b/src/main/java/com/orbitz/consul/CatalogClient.java
@@ -1,5 +1,6 @@
 package com.orbitz.consul;
 
+import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.model.catalog.CatalogNode;
 import com.orbitz.consul.model.catalog.CatalogService;
@@ -96,6 +97,20 @@ public class CatalogClient {
      */
     public ConsulResponse<List<Node>> getNodes(CatalogOptions catalogOptions, QueryOptions queryOptions) {
         return extractConsulResponse(api.getNodes(Options.from(catalogOptions, queryOptions)));
+    }
+
+    /**
+     * Asynchronously retrieves the nodes for a given datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     *
+     * GET /v1/catalog/nodes?dc={datacenter}
+     *
+     * @param catalogOptions Catalog specific options to use.
+     * @param queryOptions The Query Options to use.
+     * @param callback       Callback implemented by callee to handle results.
+     * {@link com.orbitz.consul.model.health.Node} objects.
+     */
+    public void getNodes(CatalogOptions catalogOptions, QueryOptions queryOptions, ConsulResponseCallback<List<Node>> callback) {
+        extractConsulResponse(api.getNodes(Options.from(catalogOptions, queryOptions)), callback);
     }
 
     /**

--- a/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
+++ b/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
@@ -1,0 +1,50 @@
+package com.orbitz.consul.cache;
+
+import com.google.common.base.Function;
+import com.orbitz.consul.CatalogClient;
+import com.orbitz.consul.HealthClient;
+import com.orbitz.consul.async.ConsulResponseCallback;
+import com.orbitz.consul.cache.ConsulCache;
+import com.orbitz.consul.model.health.HealthCheck;
+import com.orbitz.consul.model.health.Node;
+import com.orbitz.consul.option.CatalogOptions;
+import com.orbitz.consul.option.QueryOptions;
+
+import java.math.BigInteger;
+import java.util.List;
+
+
+public class NodesCatalogCache extends ConsulCache<String, Node> {
+
+    private NodesCatalogCache(Function<Node, String> keyConversion, CallbackConsumer<Node> callbackConsumer) {
+        super(keyConversion, callbackConsumer);
+    }
+
+    public static NodesCatalogCache newCache(
+            final CatalogClient catalogClient,
+            final CatalogOptions catalogOptions,
+            final QueryOptions queryOptions,
+            final int watchSeconds) {
+        Function<Node, String> keyExtractor = new Function<Node, String>() {
+            @Override
+            public String apply(Node node) {
+                return node.getNode();
+            }
+        };
+
+        CallbackConsumer<Node> callbackConsumer = new CallbackConsumer<Node>() {
+            @Override
+            public void consume(BigInteger index, ConsulResponseCallback<List<Node>> callback) {
+                catalogClient.getNodes(catalogOptions, watchParams(index, watchSeconds, queryOptions), callback);
+            }
+        };
+
+        return new NodesCatalogCache(keyExtractor, callbackConsumer);
+
+    }
+
+    public static NodesCatalogCache newCache(final CatalogClient catalogClient) {
+        return newCache(catalogClient, CatalogOptions.BLANK, QueryOptions.BLANK, 10);
+    }
+
+}

--- a/src/test/java/com/orbitz/consul/cache/NodesCatalogCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/NodesCatalogCacheTest.java
@@ -1,0 +1,130 @@
+package com.orbitz.consul.cache;
+
+import com.google.common.base.Equivalence;
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
+import com.google.common.hash.HashCode;
+import com.orbitz.consul.BaseIntegrationTest;
+import com.orbitz.consul.CatalogClient;
+import com.orbitz.consul.model.health.Node;
+import com.pszymczyk.consul.ConsulPorts;
+import com.pszymczyk.consul.ConsulProcess;
+import com.pszymczyk.consul.LogLevel;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.pszymczyk.consul.ConsulStarterBuilder.consulStarter;
+import static org.junit.Assert.*;
+
+public class NodesCatalogCacheTest extends BaseIntegrationTest {
+
+    @Test
+    public void nodeCacheHealthCheckTest() throws Exception {
+
+        CatalogClient catalogClient = client.catalogClient();
+
+        NodesCatalogCache nodesCatalogCache = NodesCatalogCache.newCache(catalogClient);
+
+        final CountDownLatch secondNodeRegistrationLatch = new CountDownLatch(1);
+        final CountDownLatch secondNodeDeregistrationLatch = new CountDownLatch(1);
+
+        nodesCatalogCache.addListener(new ConsulCache.Listener<String, Node>() {
+            Map<String, Node> internalNodes;
+            @Override
+            public void notify(Map<String, Node> newValues) {
+
+                try {
+                    // this function is called a first time at initialisation phase,
+                    // the initial nodes being retained locally for later diffing.
+
+                    if (internalNodes != null) {
+
+                        System.out.println(newValues);
+
+                        MapDifference<String, Node> difference = Maps.difference(
+                                internalNodes, newValues, new NodeEquivalence());
+
+                        Map<String, Node> registeredNodes = difference.entriesOnlyOnRight();
+                        Map<String, Node> deregisteredNodes = difference.entriesOnlyOnLeft();
+
+//                        assertEquals(1, registeredNodes.size() + deregisteredNodes.size());
+
+                        if (!registeredNodes.isEmpty()) {
+                            assertTrue(registeredNodes.containsKey("test-second-node"));
+                            secondNodeRegistrationLatch.countDown();
+                        }
+
+                        if (!deregisteredNodes.isEmpty()) {
+                            assertTrue(deregisteredNodes.containsKey("test-second-node"));
+                            secondNodeDeregistrationLatch.countDown();
+                        }
+
+                    }
+                } finally {
+                    internalNodes = newValues;
+                }
+
+            }
+        });
+
+        nodesCatalogCache.start();
+        nodesCatalogCache.awaitInitialized(3, TimeUnit.SECONDS);
+
+        Map<String, Node> nodes = nodesCatalogCache.getMap();
+        assertEquals(1, nodes.size());
+
+        // Start a second consul process, as agent.
+        // Ports are monotonically following the first consul process.
+        int lastPort = consul.getServerPort();
+
+        ConsulPorts consulPorts = ConsulPorts.consulPorts()
+                .withDnsPort(-1)
+                .withRpcPort(++lastPort)
+                .withSerfLanPort(++lastPort)
+                .withSerfWanPort(++lastPort)
+                .withServerPort(++lastPort).build();
+
+        // We have to force another node name to avoid collision with the consul server.
+        // Also, we start the second one as an agent to keep an odd number of servers :)
+        String customConfig = "{\n" +
+            "  \"start_join\": [\"localhost:" + consul.getSerfLanPort() + "\"], \n" +
+            "  \"node_name\": \"test-second-node\", \n" +
+            "  \"server\": false, \n" +
+            "  \"leave_on_terminate\": true \n" + // so that the node leaving the cluster will be notified immediately
+            "}";
+
+        try (ConsulProcess secondConsulAgent = consulStarter().withConsulPorts(consulPorts).withCustomConfig(customConfig).withLogLevel(LogLevel.DEBUG).build().start()) {
+
+            boolean registerSuccess = secondNodeRegistrationLatch.await(5, TimeUnit.SECONDS);
+            assertTrue(registerSuccess);
+            assertEquals(2, nodesCatalogCache.getMap().size());
+        }
+
+        boolean deregisterSuccess = secondNodeDeregistrationLatch.await(5, TimeUnit.SECONDS);
+        assertTrue(deregisterSuccess);
+
+        assertEquals(1, nodesCatalogCache.getMap().size());
+
+    }
+
+    // Note: cache is notified on any state change, i.e.
+    // is usuallly notified twice on node addition, once when the
+    // node is joining the local cluster, and a second time
+    // when it get it's WAN connection initialized.
+    // This Equivalence class avoid to diff the second notification.
+    public static class NodeEquivalence extends Equivalence<Node> {
+
+        @Override
+        protected boolean doEquivalent(Node a, Node b) {
+            return a.getNode().equals(b.getNode()) && a.getAddress().equals(b.getAddress());
+        }
+
+        @Override
+        protected int doHash(Node node) {
+            return HashCode.fromString(node.getNode() + node.getAddress()).hashCode();
+        }
+    }
+}


### PR DESCRIPTION
The idea is to have the same capability than HealthCheckCache, i.e. to have blocking call to watch changes, in the Node Catalog. This will be helpful to watch nodes registration and deregistration.