### PR TITLE
[Fix] KVCache does not work for exact key search

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/KVCache.java
+++ b/src/main/java/com/orbitz/consul/cache/KVCache.java
@@ -1,23 +1,45 @@
 package com.orbitz.consul.cache;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
-import com.google.common.collect.Sets;
+import com.google.common.base.Preconditions;
 import com.orbitz.consul.KeyValueClient;
 import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.kv.Value;
 import com.orbitz.consul.option.QueryOptions;
-import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 public class KVCache extends ConsulCache<String, Value> {
 
     private KVCache(Function<Value, String> keyConversion, ConsulCache.CallbackConsumer<Value> callbackConsumer) {
         super(keyConversion, callbackConsumer);
+    }
+
+    @VisibleForTesting
+    static Function<Value, String> getKeyExtractorFunction(final String rootPath) {
+        final String rootPathWithTrailingSlash = rootPath.endsWith("/") ? rootPath : rootPath + "/";
+        final int rootPathWithTrailingSlashLength = rootPathWithTrailingSlash.length();
+        return new Function<Value, String>() {
+            @Override
+            public String apply(Value input) {
+                Preconditions.checkNotNull(input, "Input to key extractor is null");
+                Preconditions.checkNotNull(input.getKey(), "Input to key extractor has no key");
+
+                if (rootPath.equals(input.getKey())) {
+                    return "";
+                }
+
+                boolean isRootPathAPrefix = input.getKey().startsWith(rootPathWithTrailingSlash);
+                if (isRootPathAPrefix) {
+                    return input.getKey().substring(rootPathWithTrailingSlashLength);
+                }
+
+                throw new RuntimeException(String.format("Got value for key %s but root is %s",
+                        input.getKey(), rootPathWithTrailingSlash));
+            }
+        };
     }
 
     public static KVCache newCache(
@@ -26,27 +48,7 @@ public class KVCache extends ConsulCache<String, Value> {
             final int watchSeconds,
             final QueryOptions queryOptions) {
 
-        final String rootPathWithTrailingSlash = rootPath.endsWith("/") ? rootPath : rootPath + "/";
-        final int rootPathWithTrailingSlashLength = rootPathWithTrailingSlash.length();
-
-        final Function<Value, String> keyExtractor = new Function<Value, String>() {
-            @Override
-            public String apply(Value input) {
-                if (input == null) {
-                    throw new RuntimeException("Input to key extractor is null");
-                }
-                if (input.getKey() == null) {
-                    throw new RuntimeException("Input to key extractor has no key");
-                }
-
-                if (input.getKey().startsWith(rootPathWithTrailingSlash)) {
-                    return input.getKey().substring(rootPathWithTrailingSlashLength);
-                } else {
-                    throw new RuntimeException(String.format("Got value for key %s but root is %s",
-                        input.getKey(), rootPathWithTrailingSlash));
-                }
-            }
-        };
+        final Function<Value, String> keyExtractor = getKeyExtractorFunction(rootPath);
 
         final CallbackConsumer<Value> callbackConsumer = new CallbackConsumer<Value>() {
             @Override

--- a/src/test/java/com/orbitz/consul/cache/KVCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/KVCacheTest.java
@@ -1,0 +1,54 @@
+package com.orbitz.consul.cache;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.orbitz.consul.model.kv.ImmutableValue;
+import com.orbitz.consul.model.kv.Value;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class KVCacheTest {
+
+    private Function<Value, String> keyExtractor;
+
+    @Before
+    public void setUp() {
+        keyExtractor = KVCache.getKeyExtractorFunction("a/b");
+    }
+
+    @Test
+    public void testSameRootPathAndKeyNoSlash() {
+        String actualKey = keyExtractor.apply(createValue("a/b"));
+        Assert.assertEquals("", actualKey);
+    }
+
+    @Test
+    public void testSameRootPathAndKeyWithSlash() {
+        String actualKey = keyExtractor.apply(createValue("a/b/"));
+        Assert.assertEquals("", actualKey);
+    }
+
+    @Test
+    public void testRootPathHasSubkeysNoSlash() {
+        String actualKey = keyExtractor.apply(createValue("a/b/c"));
+        Assert.assertEquals("c", actualKey);
+    }
+
+    @Test
+    public void testRootPathHasSubkeysWithSlash() {
+        String actualKey = keyExtractor.apply(createValue("a/b/c/d/"));
+        Assert.assertEquals("c/d/", actualKey);
+    }
+
+    private Value createValue(final String key) {
+        return ImmutableValue.builder()
+                .createIndex(1234567890)
+                .modifyIndex(1234567890)
+                .lockIndex(1234567890)
+                .flags(1234567890)
+                .key(key)
+                .value(Optional.<String>absent())
+                .build();
+    }
+}


### PR DESCRIPTION
Commit 3714976 changes the way the prefix are removed from the key.
It works fine for key/subkey pattern but fails when we are looking for the
exact key (for intance, "a/b").