### PR TITLE
Allows to override key extractor

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
+++ b/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
@@ -30,13 +30,8 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
             final com.orbitz.consul.model.State state,
             final CatalogOptions catalogOptions,
             final int watchSeconds,
-            final QueryOptions queryOptions) {
-        Function<HealthCheck, String> keyExtractor = new Function<HealthCheck, String>() {
-            @Override
-            public String apply(HealthCheck input) {
-                return input.getCheckId();
-            }
-        };
+            final QueryOptions queryOptions,
+            Function<HealthCheck, String> keyExtractor) {
 
         CallbackConsumer<HealthCheck> callbackConsumer = new CallbackConsumer<HealthCheck>() {
             @Override
@@ -47,7 +42,23 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
         };
 
         return new HealthCheckCache(keyExtractor, callbackConsumer);
+    }
 
+    public static HealthCheckCache newCache(
+            final HealthClient healthClient,
+            final com.orbitz.consul.model.State state,
+            final CatalogOptions catalogOptions,
+            final int watchSeconds,
+            final QueryOptions queryOptions) {
+
+        Function<HealthCheck, String> keyExtractor = new Function<HealthCheck, String>() {
+            @Override
+            public String apply(HealthCheck input) {
+                return input.getCheckId();
+            }
+        };
+
+        return newCache(healthClient, state, catalogOptions, watchSeconds, queryOptions, keyExtractor);
     }
 
     public static HealthCheckCache newCache(

--- a/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
@@ -33,13 +33,8 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
             final boolean passing,
             final CatalogOptions catalogOptions,
             final int watchSeconds,
-            final QueryOptions queryOptions) {
-        Function<ServiceHealth, ServiceHealthKey> keyExtractor = new Function<ServiceHealth, ServiceHealthKey>() {
-            @Override
-            public ServiceHealthKey apply(ServiceHealth input) {
-                return ServiceHealthKey.fromServiceHealth(input);
-            }
-        };
+            final QueryOptions queryOptions,
+            final Function<ServiceHealth, ServiceHealthKey> keyExtractor) {
 
         CallbackConsumer<ServiceHealth> callbackConsumer = new CallbackConsumer<ServiceHealth>() {
             @Override
@@ -56,6 +51,24 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
         return new ServiceHealthCache(keyExtractor, callbackConsumer);
     }
 
+    public static ServiceHealthCache newCache(
+            final HealthClient healthClient,
+            final String serviceName,
+            final boolean passing,
+            final CatalogOptions catalogOptions,
+            final int watchSeconds,
+            final QueryOptions queryOptions) {
+
+        Function<ServiceHealth, ServiceHealthKey> keyExtractor = new Function<ServiceHealth, ServiceHealthKey>() {
+            @Override
+            public ServiceHealthKey apply(ServiceHealth input) {
+                return ServiceHealthKey.fromServiceHealth(input);
+            }
+        };
+
+        return newCache(healthClient, serviceName, passing, catalogOptions, watchSeconds, queryOptions, keyExtractor);
+    }
+    
     public static ServiceHealthCache newCache(
             final HealthClient healthClient,
             final String serviceName,


### PR DESCRIPTION
In some scenario, having the key extractor returning only the check Id might not be sufficient and generate overlap in check Ids, for instance when several nodes have the same local check -- allowing the key extractor to be overridden is necessary.