### PR TITLE
Override default backoff delay for Cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ gradle/gradlew
 gradle/gradlew.bat
 gradle/gradle
 src/gradle
+.classpath
+.project
+.settings

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In 0.11.X and 0.12.x, the Consul JAR is a shaded JAR, with most dependencies inc
 
 ### Bintray:
 
-Grab the latest binary (0.13.1) [here](http://dl.bintray.com/orbitz/consul-client/com/orbitz/consul/consul-client/0.12.0/#consul-client-0.12.0.jar).
+Grab the latest binary (0.13.2) [here](http://dl.bintray.com/orbitz/consul-client/com/orbitz/consul/consul-client/0.12.0/#consul-client-0.12.0.jar).
 
 ### Gradle:
 
@@ -28,7 +28,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.orbitz.consul:consul-client:0.13.1'
+    compile 'com.orbitz.consul:consul-client:0.13.2'
 }
 ```
 
@@ -39,7 +39,7 @@ dependencies {
     <dependency>
         <groupId>com.orbitz.consul</groupId>
         <artifactId>consul-client</artifactId>
-        <version>0.13.1</version>
+        <version>0.13.2</version>
     </dependency>
 </dependencies>
 

--- a/README.md
+++ b/README.md
@@ -99,42 +99,42 @@ String value = kvClient.getValueAsString("foo").get(); // bar
 A blocking is used to wait for a potential changes in the key value store. 
 
 ```java
-        Consul consul = Consul.builder().build();
-        final KeyValueClient kvClient = consul.keyValueClient();
+Consul consul = Consul.builder().build();
+final KeyValueClient kvClient = consul.keyValueClient();
 
-        kvClient.putValue("foo", "bar");
+kvClient.putValue("foo", "bar");
 
-        ConsulResponseCallback<Optional<Value>> callback = new ConsulResponseCallback<Optional<Value>>() {
+ConsulResponseCallback<Optional<Value>> callback = new ConsulResponseCallback<Optional<Value>>() {
 
-            AtomicReference<BigInteger> index = new AtomicReference<BigInteger>(null);
+    AtomicReference<BigInteger> index = new AtomicReference<BigInteger>(null);
 
-            @Override
-            public void onComplete(ConsulResponse<Optional<Value>> consulResponse) {
+    @Override
+    public void onComplete(ConsulResponse<Optional<Value>> consulResponse) {
 
-                if (consulResponse.getResponse().isPresent()) {
-                    Value v = consulResponse.getResponse().get();
-                    LOGGER.info("Value is: {}", new String(BaseEncoding.base64().decode(v.getValue().toString())));
-                }
-                index.set(consulResponse.getIndex());
-                watch();
-            }
+        if (consulResponse.getResponse().isPresent()) {
+            Value v = consulResponse.getResponse().get();
+            LOGGER.info("Value is: {}", new String(BaseEncoding.base64().decode(v.getValue().toString())));
+        }
+        
+	index.set(consulResponse.getIndex());
+        watch();
+    }
 
-            void watch() {
-                kvClient.getValue("foo", QueryOptions.blockMinutes(5, index.get()).build(), this);
-            }
+    void watch() {
+        kvClient.getValue("foo", QueryOptions.blockMinutes(5, index.get()).build(), this);
+    }
 
-            @Override
-            public void onFailure(Throwable throwable) {
-                LOGGER.error("Error encountered", throwable);
-                watch();
-            }
-        };
+    @Override
+        public void onFailure(Throwable throwable) {
+            LOGGER.error("Error encountered", throwable);
+            watch();
+        }
+    };
 
-        kvClient.getValue("foo", QueryOptions.blockMinutes(5, new BigInteger("0")).build(), callback);
-
+    kvClient.getValue("foo", QueryOptions.blockMinutes(5, new BigInteger("0")).build(), callback);
 ```
 
-### Example 6: Subscribe to healthy services
+### Example 5: Subscribe to healthy services
 
 You can also use the ConsulCache implementations to easily subscribe to healthy service changes or Key-Value changes.
 
@@ -154,7 +154,7 @@ svHealth.addListener(new ConsulCache.Listener<HostAndPort, ServiceHealth>() {
 svHealth.start();
 ```         
 
-### Example 7: Find Raft peers.
+### Example 6: Find Raft peers.
 
 ```java
 StatusClient statusClient = Consul.builder().build().statusClient();
@@ -164,7 +164,7 @@ for(String peer : statusClient.getPeers()) {
 }
 ```
 
-### Example 8: Find Raft leader.
+### Example 7: Find Raft leader.
 
 ```java
 StatusClient statusClient = Consul.builder().build().statusClient();

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ String value = kvClient.getValueAsString("foo").get(); // bar
 
 ### Example 4: Blocking call for value.
 
+A blocking is used to wait for a potential changes in the key value store. 
+
 ```java
         Consul consul = Consul.builder().build();
         final KeyValueClient kvClient = consul.keyValueClient();

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.orbitz.consul</groupId>
     <artifactId>consul-client</artifactId>
     <packaging>jar</packaging>
-    <version>0.13.1</version>
+    <version>0.13.2</version>
     <name>consul-client</name>
     <url>http://maven.apache.org</url>
     <description>Consul Client for Java</description>

--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -46,12 +46,17 @@ public class Consul {
     private final EventClient eventClient;
     private final PreparedQueryClient preparedQueryClient;
     private final CoordinateClient coordinateClient;
+    private final OperatorClient operatorClient;
 
     /**
      * Private constructor.
      *
      */
-    private Consul(AgentClient agentClient, HealthClient healthClient, KeyValueClient keyValueClient, CatalogClient catalogClient, StatusClient statusClient, SessionClient sessionClient, EventClient eventClient, PreparedQueryClient preparedQueryClient, CoordinateClient coordinateClient) {
+    private Consul(AgentClient agentClient, HealthClient healthClient,
+                   KeyValueClient keyValueClient, CatalogClient catalogClient,
+                   StatusClient statusClient, SessionClient sessionClient,
+                   EventClient eventClient, PreparedQueryClient preparedQueryClient,
+                   CoordinateClient coordinateClient, OperatorClient operatorClient) {
         this.agentClient = agentClient;
         this.healthClient = healthClient;
         this.keyValueClient = keyValueClient;
@@ -61,6 +66,7 @@ public class Consul {
         this.eventClient = eventClient;
         this.preparedQueryClient = preparedQueryClient;
         this.coordinateClient = coordinateClient;
+        this.operatorClient = operatorClient;
     }
 
 
@@ -164,6 +170,16 @@ public class Consul {
         return coordinateClient;
     }
 
+    /**
+     * Get the Operator HTTP client.
+     * <p>
+     * /v1/operator
+     *
+     * @return The Operator HTTP client.
+     */
+    public OperatorClient operatorClient() {
+        return operatorClient;
+    }
     /**
      * Creates a new {@link Builder} object.
      *
@@ -413,11 +429,14 @@ public class Consul {
             EventClient eventClient = new EventClient(retrofit);
             PreparedQueryClient preparedQueryClient = new PreparedQueryClient(retrofit);
             CoordinateClient coordinateClient = new CoordinateClient(retrofit);
+            OperatorClient operatorClient = new OperatorClient(retrofit);
 
             if (ping) {
                 agentClient.ping();
             }
-            return new Consul(agentClient, healthClient, keyValueClient, catalogClient, statusClient, sessionClient, eventClient, preparedQueryClient, coordinateClient);
+            return new Consul(agentClient, healthClient, keyValueClient,
+                    catalogClient, statusClient, sessionClient, eventClient,
+                    preparedQueryClient, coordinateClient, operatorClient);
         }
 
         private String buildUrl(URL url) {

--- a/src/main/java/com/orbitz/consul/KeyValueClient.java
+++ b/src/main/java/com/orbitz/consul/KeyValueClient.java
@@ -7,6 +7,7 @@ import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.model.kv.Value;
 import com.orbitz.consul.model.session.SessionInfo;
+import com.orbitz.consul.option.DeleteOptions;
 import com.orbitz.consul.option.ImmutablePutOptions;
 import com.orbitz.consul.option.PutOptions;
 import com.orbitz.consul.option.QueryOptions;
@@ -275,7 +276,7 @@ public class KeyValueClient {
      * @param key The key to delete.
      */
     public void deleteKey(String key) {
-        handle(api.deleteValue(trimLeadingSlash(key)));
+        deleteKey(key, DeleteOptions.BLANK);
     }
 
     /**
@@ -286,7 +287,22 @@ public class KeyValueClient {
      * @param key The key to delete.
      */
     public void deleteKeys(String key) {
-        handle(api.deleteValues(trimLeadingSlash(key), ImmutableMap.of("recurse", "true")));
+        deleteKey(key, DeleteOptions.RECURSE);
+    }
+
+    /**
+     * Deletes a specified key.
+     *
+     * DELETE /v1/kv/{key}
+     *
+     * @param key The key to delete.
+     * @param deleteOptions DELETE options (e.g. recurse, cas)
+     */
+    public void deleteKey(String key, DeleteOptions deleteOptions) {
+        checkArgument(StringUtils.isNotEmpty(key), "Key must be defined");
+        Map<String, Object> query = deleteOptions.toQuery();
+
+        handle(api.deleteValues(trimLeadingSlash(key), query));
     }
 
     /**
@@ -366,10 +382,7 @@ public class KeyValueClient {
                                @QueryMap Map<String, Object> query);
 
         @DELETE("kv/{key}")
-        Call<Void> deleteValue(@Path("key") String key);
-
-        @DELETE("kv/{key}")
         Call<Void> deleteValues(@Path("key") String key,
-                                @QueryMap Map<String, String> query);
+                                @QueryMap Map<String, Object> query);
     }
 }

--- a/src/main/java/com/orbitz/consul/KeyValueClient.java
+++ b/src/main/java/com/orbitz/consul/KeyValueClient.java
@@ -30,6 +30,7 @@ import static com.orbitz.consul.util.Strings.trimLeadingSlash;
  */
 public class KeyValueClient {
 
+    public static final int NOT_FOUND_404 = 404;
     private final Api api;
 
     /**
@@ -66,9 +67,9 @@ public class KeyValueClient {
      */
     public Optional<Value> getValue(String key, QueryOptions queryOptions) {
         try {
-            return getSingleValue(extract(api.getValue(trimLeadingSlash(key), queryOptions.toQuery())));
+            return getSingleValue(extract(api.getValue(trimLeadingSlash(key), queryOptions.toQuery()), NOT_FOUND_404));
         } catch (ConsulException ignored) {
-            if(ignored.getCode() != 404) {
+            if(ignored.getCode() != NOT_FOUND_404) {
                 throw ignored;
             }
         }
@@ -102,7 +103,7 @@ public class KeyValueClient {
             }
         };
 
-        extractConsulResponse(api.getValue(trimLeadingSlash(key), queryOptions.toQuery()), wrapper);
+        extractConsulResponse(api.getValue(trimLeadingSlash(key), queryOptions.toQuery()), wrapper, NOT_FOUND_404);
     }
 
     private Optional<Value> getSingleValue(List<Value> values){
@@ -137,7 +138,7 @@ public class KeyValueClient {
 
         query.put("recurse", "true");
 
-        return extract(api.getValue(trimLeadingSlash(key), query));
+        return extract(api.getValue(trimLeadingSlash(key), query), NOT_FOUND_404);
     }
 
     /**
@@ -155,7 +156,7 @@ public class KeyValueClient {
 
         query.put("recurse", "true");
 
-        extractConsulResponse(api.getValue(trimLeadingSlash(key), query), callback);
+        extractConsulResponse(api.getValue(trimLeadingSlash(key), query), callback, NOT_FOUND_404);
     }
 
     /**

--- a/src/main/java/com/orbitz/consul/OperatorClient.java
+++ b/src/main/java/com/orbitz/consul/OperatorClient.java
@@ -1,0 +1,62 @@
+package com.orbitz.consul;
+
+import com.google.common.collect.ImmutableMap;
+import com.orbitz.consul.model.operator.RaftConfiguration;
+import retrofit2.Call;
+import retrofit2.Retrofit;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+import retrofit2.http.QueryMap;
+
+import java.util.Map;
+
+import static com.orbitz.consul.util.Http.extract;
+import static com.orbitz.consul.util.Http.handle;
+
+public class OperatorClient {
+
+    private final Api api;
+
+    OperatorClient(Retrofit retrofit) {
+        this.api = retrofit.create(Api.class);
+    }
+
+    public RaftConfiguration getRaftConfiguration() {
+        return extract(api.getConfiguration(ImmutableMap.<String, String>of()));
+    }
+
+    public RaftConfiguration getRaftConfiguration(String datacenter) {
+        return extract(api.getConfiguration(ImmutableMap.of("dc", datacenter)));
+    }
+
+    public RaftConfiguration getStaleRaftConfiguration(String datacenter) {
+        return extract(api.getConfiguration(ImmutableMap.of(
+            "dc", datacenter, "stale", "true"
+        )));
+    }
+
+    public RaftConfiguration getStaleRaftConfiguration() {
+        return extract(api.getConfiguration(ImmutableMap.of(
+                "stale", "true"
+        )));
+    }
+
+    public void deletePeer(String address) {
+        handle(api.deletePeer(address, ImmutableMap.<String, String>of()));
+    }
+
+    public void deletePeer(String address, String datacenter) {
+        handle(api.deletePeer(address, ImmutableMap.of("dc", datacenter)));
+    }
+
+    interface Api {
+
+        @GET("operator/raft/configuration")
+        Call<RaftConfiguration> getConfiguration(@QueryMap Map<String, String> query);
+
+        @DELETE("operator/raft/peer")
+        Call<Void> deletePeer(@Query("address") String address,
+                              @QueryMap Map<String, String> query);
+    }
+}

--- a/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
+++ b/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
@@ -30,13 +30,8 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
             final com.orbitz.consul.model.State state,
             final CatalogOptions catalogOptions,
             final int watchSeconds,
-            final QueryOptions queryOptions) {
-        Function<HealthCheck, String> keyExtractor = new Function<HealthCheck, String>() {
-            @Override
-            public String apply(HealthCheck input) {
-                return input.getCheckId();
-            }
-        };
+            final QueryOptions queryOptions,
+            Function<HealthCheck, String> keyExtractor) {
 
         CallbackConsumer<HealthCheck> callbackConsumer = new CallbackConsumer<HealthCheck>() {
             @Override
@@ -47,7 +42,23 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
         };
 
         return new HealthCheckCache(keyExtractor, callbackConsumer);
+    }
 
+    public static HealthCheckCache newCache(
+            final HealthClient healthClient,
+            final com.orbitz.consul.model.State state,
+            final CatalogOptions catalogOptions,
+            final int watchSeconds,
+            final QueryOptions queryOptions) {
+
+        Function<HealthCheck, String> keyExtractor = new Function<HealthCheck, String>() {
+            @Override
+            public String apply(HealthCheck input) {
+                return input.getCheckId();
+            }
+        };
+
+        return newCache(healthClient, state, catalogOptions, watchSeconds, queryOptions, keyExtractor);
     }
 
     public static HealthCheckCache newCache(

--- a/src/main/java/com/orbitz/consul/cache/KVCache.java
+++ b/src/main/java/com/orbitz/consul/cache/KVCache.java
@@ -1,23 +1,45 @@
 package com.orbitz.consul.cache;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
-import com.google.common.collect.Sets;
+import com.google.common.base.Preconditions;
 import com.orbitz.consul.KeyValueClient;
 import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.kv.Value;
 import com.orbitz.consul.option.QueryOptions;
-import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 public class KVCache extends ConsulCache<String, Value> {
 
     private KVCache(Function<Value, String> keyConversion, ConsulCache.CallbackConsumer<Value> callbackConsumer) {
         super(keyConversion, callbackConsumer);
+    }
+
+    @VisibleForTesting
+    static Function<Value, String> getKeyExtractorFunction(final String rootPath) {
+        final String rootPathWithTrailingSlash = rootPath.endsWith("/") ? rootPath : rootPath + "/";
+        final int rootPathWithTrailingSlashLength = rootPathWithTrailingSlash.length();
+        return new Function<Value, String>() {
+            @Override
+            public String apply(Value input) {
+                Preconditions.checkNotNull(input, "Input to key extractor is null");
+                Preconditions.checkNotNull(input.getKey(), "Input to key extractor has no key");
+
+                if (rootPath.equals(input.getKey())) {
+                    return "";
+                }
+
+                boolean isRootPathAPrefix = input.getKey().startsWith(rootPathWithTrailingSlash);
+                if (isRootPathAPrefix) {
+                    return input.getKey().substring(rootPathWithTrailingSlashLength);
+                }
+
+                throw new RuntimeException(String.format("Got value for key %s but root is %s",
+                        input.getKey(), rootPathWithTrailingSlash));
+            }
+        };
     }
 
     public static KVCache newCache(
@@ -26,27 +48,7 @@ public class KVCache extends ConsulCache<String, Value> {
             final int watchSeconds,
             final QueryOptions queryOptions) {
 
-        final String rootPathWithTrailingSlash = rootPath.endsWith("/") ? rootPath : rootPath + "/";
-        final int rootPathWithTrailingSlashLength = rootPathWithTrailingSlash.length();
-
-        final Function<Value, String> keyExtractor = new Function<Value, String>() {
-            @Override
-            public String apply(Value input) {
-                if (input == null) {
-                    throw new RuntimeException("Input to key extractor is null");
-                }
-                if (input.getKey() == null) {
-                    throw new RuntimeException("Input to key extractor has no key");
-                }
-
-                if (input.getKey().startsWith(rootPathWithTrailingSlash)) {
-                    return input.getKey().substring(rootPathWithTrailingSlashLength);
-                } else {
-                    throw new RuntimeException(String.format("Got value for key %s but root is %s",
-                        input.getKey(), rootPathWithTrailingSlash));
-                }
-            }
-        };
+        final Function<Value, String> keyExtractor = getKeyExtractorFunction(rootPath);
 
         final CallbackConsumer<Value> callbackConsumer = new CallbackConsumer<Value>() {
             @Override

--- a/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
@@ -33,13 +33,8 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
             final boolean passing,
             final CatalogOptions catalogOptions,
             final int watchSeconds,
-            final QueryOptions queryOptions) {
-        Function<ServiceHealth, ServiceHealthKey> keyExtractor = new Function<ServiceHealth, ServiceHealthKey>() {
-            @Override
-            public ServiceHealthKey apply(ServiceHealth input) {
-                return ServiceHealthKey.fromServiceHealth(input);
-            }
-        };
+            final QueryOptions queryOptions,
+            final Function<ServiceHealth, ServiceHealthKey> keyExtractor) {
 
         CallbackConsumer<ServiceHealth> callbackConsumer = new CallbackConsumer<ServiceHealth>() {
             @Override
@@ -56,6 +51,24 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
         return new ServiceHealthCache(keyExtractor, callbackConsumer);
     }
 
+    public static ServiceHealthCache newCache(
+            final HealthClient healthClient,
+            final String serviceName,
+            final boolean passing,
+            final CatalogOptions catalogOptions,
+            final int watchSeconds,
+            final QueryOptions queryOptions) {
+
+        Function<ServiceHealth, ServiceHealthKey> keyExtractor = new Function<ServiceHealth, ServiceHealthKey>() {
+            @Override
+            public ServiceHealthKey apply(ServiceHealth input) {
+                return ServiceHealthKey.fromServiceHealth(input);
+            }
+        };
+
+        return newCache(healthClient, serviceName, passing, catalogOptions, watchSeconds, queryOptions, keyExtractor);
+    }
+    
     public static ServiceHealthCache newCache(
             final HealthClient healthClient,
             final String serviceName,

--- a/src/main/java/com/orbitz/consul/model/kv/Operation.java
+++ b/src/main/java/com/orbitz/consul/model/kv/Operation.java
@@ -1,0 +1,43 @@
+package com.orbitz.consul.model.kv;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Optional;
+import com.orbitz.consul.util.Base64EncodingDeserializer;
+import com.orbitz.consul.util.Base64EncodingSerializer;
+import org.immutables.value.Value;
+
+import java.math.BigInteger;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableOperation.class)
+@JsonSerialize(as = ImmutableOperation.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class Operation {
+
+    @JsonProperty("Verb")
+    public abstract String verb();
+
+    @JsonProperty("Key")
+    public abstract Optional<String> key();
+
+    @JsonProperty("Value")
+    @JsonSerialize(using = Base64EncodingSerializer.class)
+    @JsonDeserialize(using = Base64EncodingDeserializer.class)
+    public abstract Optional<String> value();
+
+    @JsonProperty("Flags")
+    public abstract Optional<Long> flags();
+
+    @JsonProperty("Index")
+    public abstract Optional<BigInteger> index();
+
+    @JsonProperty("Session")
+    public abstract Optional<String> session();
+
+    public static ImmutableOperation.Builder builder(Verb verb) {
+        return ImmutableOperation.builder().verb(verb.toValue());
+    }
+}

--- a/src/main/java/com/orbitz/consul/model/kv/TxError.java
+++ b/src/main/java/com/orbitz/consul/model/kv/TxError.java
@@ -1,0 +1,22 @@
+package com.orbitz.consul.model.kv;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Optional;
+
+import java.math.BigInteger;
+
+@org.immutables.value.Value.Immutable
+@JsonDeserialize(as = ImmutableTxError.class)
+@JsonSerialize(as = ImmutableTxError.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class TxError {
+
+    @JsonProperty("OpIndex")
+    public abstract Optional<BigInteger> opIndex();
+
+    @JsonProperty("What")
+    public abstract Optional<String> what();
+}

--- a/src/main/java/com/orbitz/consul/model/kv/TxResponse.java
+++ b/src/main/java/com/orbitz/consul/model/kv/TxResponse.java
@@ -1,0 +1,22 @@
+package com.orbitz.consul.model.kv;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.util.List;
+import java.util.Map;
+
+@org.immutables.value.Value.Immutable
+@JsonDeserialize(as = ImmutableTxResponse.class)
+@JsonSerialize(as = ImmutableTxResponse.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class TxResponse {
+
+    @JsonProperty("Results")
+    public abstract List<Map<String, Value>> results();
+
+    @JsonProperty("Errors")
+    public abstract List<TxError> errors();
+}

--- a/src/main/java/com/orbitz/consul/model/kv/Verb.java
+++ b/src/main/java/com/orbitz/consul/model/kv/Verb.java
@@ -1,0 +1,18 @@
+package com.orbitz.consul.model.kv;
+
+public enum Verb {
+
+    SET("set"), CHECK_AND_SET("cas"), LOCK("lock"), UNLOCK("unlock"), GET("get"),
+    GET_TREE("get-tree"), CHECK_INDEX("check-index"), CHECK_SESSION("check-session"),
+    DELETE("delete"), DELETE_TREE("delete-tree"), DELETE_CHECK_AND_SET("delete-cas");
+
+    private String value;
+
+    Verb(String value) {
+        this.value = value;
+    }
+
+    public String toValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/orbitz/consul/model/operator/RaftConfiguration.java
+++ b/src/main/java/com/orbitz/consul/model/operator/RaftConfiguration.java
@@ -1,0 +1,22 @@
+package com.orbitz.consul.model.operator;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.math.BigInteger;
+import java.util.List;
+
+@org.immutables.value.Value.Immutable
+@JsonDeserialize(as = ImmutableRaftConfiguration.class)
+@JsonSerialize(as = ImmutableRaftConfiguration.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class RaftConfiguration {
+
+    @JsonProperty("Servers")
+    public abstract List<RaftServer> servers();
+
+    @JsonProperty("Index")
+    public abstract BigInteger index();
+}

--- a/src/main/java/com/orbitz/consul/model/operator/RaftServer.java
+++ b/src/main/java/com/orbitz/consul/model/operator/RaftServer.java
@@ -1,0 +1,28 @@
+package com.orbitz.consul.model.operator;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@org.immutables.value.Value.Immutable
+@JsonDeserialize(as = ImmutableRaftServer.class)
+@JsonSerialize(as = ImmutableRaftServer.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class RaftServer {
+
+    @JsonProperty("ID")
+    public abstract String id();
+
+    @JsonProperty("Node")
+    public abstract String node();
+
+    @JsonProperty("Address")
+    public abstract String address();
+
+    @JsonProperty("Leader")
+    public abstract Boolean leader();
+
+    @JsonProperty("Voter")
+    public abstract Boolean voter();
+}

--- a/src/main/java/com/orbitz/consul/option/ConsistencyMode.java
+++ b/src/main/java/com/orbitz/consul/option/ConsistencyMode.java
@@ -1,5 +1,17 @@
 package com.orbitz.consul.option;
 
+import com.google.common.base.Optional;
+
 public enum ConsistencyMode {
-    DEFAULT, STALE, CONSISTENT
+    DEFAULT(null), STALE("stale"), CONSISTENT("consistent");
+
+    private String param;
+
+    ConsistencyMode(String param) {
+        this.param = param;
+    }
+
+    public Optional<String> toParam() {
+        return Optional.fromNullable(param);
+    }
 }

--- a/src/main/java/com/orbitz/consul/option/DeleteOptions.java
+++ b/src/main/java/com/orbitz/consul/option/DeleteOptions.java
@@ -1,0 +1,39 @@
+package com.orbitz.consul.option;
+
+import static com.orbitz.consul.option.Options.optionallyAdd;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.immutables.value.Value;
+
+import com.google.common.base.Optional;
+
+@Value.Immutable
+public abstract class DeleteOptions implements ParamAdder {
+
+	public static final DeleteOptions BLANK = ImmutableDeleteOptions.builder().build();
+	public static final DeleteOptions RECURSE = ImmutableDeleteOptions.builder().recurse(true).build();
+
+	public abstract Optional<Long> getCas();
+
+	public abstract Optional<Boolean> getRecurse();
+
+	@Value.Derived
+	public boolean isRecurse() {
+		return getRecurse().isPresent();
+	}
+
+	@Override
+	public Map<String, Object> toQuery() {
+		final Map<String, Object> result = new HashMap<>();
+
+		if (isRecurse()) {
+			result.put("recurse", "");
+		}
+
+		optionallyAdd(result, "cas", getCas());
+
+		return result;
+	}
+}

--- a/src/main/java/com/orbitz/consul/util/Base64EncodingSerializer.java
+++ b/src/main/java/com/orbitz/consul/util/Base64EncodingSerializer.java
@@ -1,0 +1,22 @@
+package com.orbitz.consul.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.google.common.base.Optional;
+import com.google.common.io.BaseEncoding;
+
+import java.io.IOException;
+
+public class Base64EncodingSerializer extends JsonSerializer<Optional<String>> {
+
+    @Override
+    public void serialize(Optional<String> string, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
+        if (string.isPresent()) {
+            jsonGenerator.writeString(BaseEncoding.base64().encode(string.get().getBytes()));
+        } else {
+            jsonGenerator.writeNull();
+        }
+    }
+}

--- a/src/test/java/com/orbitz/consul/KeyValueTests.java
+++ b/src/test/java/com/orbitz/consul/KeyValueTests.java
@@ -17,9 +17,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class KeyValueTests extends BaseIntegrationTest {
 
@@ -257,19 +255,18 @@ public class KeyValueTests extends BaseIntegrationTest {
 
             @Override
             public void onComplete(ConsulResponse<Optional<Value>> consulResponse) {
+                assertNotNull(consulResponse);
                 completed.countDown();
             }
 
             @Override
             public void onFailure(Throwable throwable) {
-                success.set(throwable instanceof ConsulException);;
-                completed.countDown();
+                fail("404 isn't a failure for KVs");
             }
         });
 
         completed.await(3, TimeUnit.SECONDS);
         keyValueClient.deleteKey(key);
-        assertTrue(success.get());
-
+        assertFalse(success.get());
     }
 }

--- a/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
@@ -14,15 +14,12 @@ import com.orbitz.consul.model.kv.Value;
 import com.orbitz.consul.option.ConsistencyMode;
 import com.orbitz.consul.option.ImmutableQueryOptions;
 import com.orbitz.consul.option.QueryOptions;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
@@ -260,7 +257,7 @@ public class ConsulCacheTest extends BaseIntegrationTest {
         nc.start();
         assertEquals(ConsulCache.State.starting, nc.getState());
 
-        if (!nc.awaitInitialized(1, TimeUnit.SECONDS)) {
+        if (!nc.awaitInitialized(10, TimeUnit.SECONDS)) {
             fail("cache initialization failed");
         }
         assertEquals(ConsulCache.State.started, nc.getState());
@@ -377,5 +374,25 @@ public class ConsulCacheTest extends BaseIntegrationTest {
                 .wait("10s")
                 .build();
         ConsulCache.watchParams(index, 10, additionalOptions);
+    }
+
+    @Test
+    public void testDefaultBackOffDelay() {
+        Properties properties = new Properties();
+        Assert.assertEquals(10000L, ConsulCache.getBackOffDelayInMs(properties));
+    }
+
+    @Test
+    public void testBackOffDelayFromProperties() {
+        Properties properties = new Properties();
+        properties.setProperty(ConsulCache.BACKOFF_DELAY_PROPERTY, "500");
+        Assert.assertEquals(500L, ConsulCache.getBackOffDelayInMs(properties));
+    }
+
+    @Test
+    public void testBackOffDelayDoesNotThrow() {
+        Properties properties = new Properties();
+        properties.setProperty(ConsulCache.BACKOFF_DELAY_PROPERTY, "unparseableLong");
+        Assert.assertEquals(10000L, ConsulCache.getBackOffDelayInMs(properties));
     }
 }

--- a/src/test/java/com/orbitz/consul/cache/KVCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/KVCacheTest.java
@@ -1,0 +1,54 @@
+package com.orbitz.consul.cache;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.orbitz.consul.model.kv.ImmutableValue;
+import com.orbitz.consul.model.kv.Value;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class KVCacheTest {
+
+    private Function<Value, String> keyExtractor;
+
+    @Before
+    public void setUp() {
+        keyExtractor = KVCache.getKeyExtractorFunction("a/b");
+    }
+
+    @Test
+    public void testSameRootPathAndKeyNoSlash() {
+        String actualKey = keyExtractor.apply(createValue("a/b"));
+        Assert.assertEquals("", actualKey);
+    }
+
+    @Test
+    public void testSameRootPathAndKeyWithSlash() {
+        String actualKey = keyExtractor.apply(createValue("a/b/"));
+        Assert.assertEquals("", actualKey);
+    }
+
+    @Test
+    public void testRootPathHasSubkeysNoSlash() {
+        String actualKey = keyExtractor.apply(createValue("a/b/c"));
+        Assert.assertEquals("c", actualKey);
+    }
+
+    @Test
+    public void testRootPathHasSubkeysWithSlash() {
+        String actualKey = keyExtractor.apply(createValue("a/b/c/d/"));
+        Assert.assertEquals("c/d/", actualKey);
+    }
+
+    private Value createValue(final String key) {
+        return ImmutableValue.builder()
+                .createIndex(1234567890)
+                .modifyIndex(1234567890)
+                .lockIndex(1234567890)
+                .flags(1234567890)
+                .key(key)
+                .value(Optional.<String>absent())
+                .build();
+    }
+}


### PR DESCRIPTION
Default backoff delay for caches is equal to 10s.
Enable this value to be overriden from properties if such a property exists.
For instance, "-Dcom.orbitz.consul.cache.backOffDelay=500".

I chose to use properties as the code of caches starts to grow fast, some
caches already have 4 constructors and i think it could be better to avoid
the creation of another one.