### PR TITLE
Fix KVCache when using root keys.

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/KVCache.java
+++ b/src/main/java/com/orbitz/consul/cache/KVCache.java
@@ -27,6 +27,10 @@ public class KVCache extends ConsulCache<String, Value> {
                 Preconditions.checkNotNull(input, "Input to key extractor is null");
                 Preconditions.checkNotNull(input.getKey(), "Input to key extractor has no key");
 
+                if (rootPathWithTrailingSlashLength == 1) {
+                    return input.getKey();
+                }
+
                 if (rootPath.equals(input.getKey())) {
                     return "";
                 }


### PR DESCRIPTION
Fixes KVCache when root path is set to "/". This was working fine in some previous versions (e.g. 0.9.15), so I assume this is unintended regression.