### PR TITLE
because of changes in consul 0.7.3 there is need to not use connection limit in case of long pooling

### DIFF
--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -550,6 +550,8 @@ public class Consul {
              */
             Dispatcher dispatcher = new Dispatcher(new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS,
                     new SynchronousQueue<Runnable>(), Util.threadFactory("OkHttp Dispatcher", true)));
+            dispatcher.setMaxRequests(Integer.MAX_VALUE);
+            dispatcher.setMaxRequestsPerHost(Integer.MAX_VALUE);
             builder.dispatcher(dispatcher);
 
             final URL consulUrl = new URL(url);


### PR DESCRIPTION
because of changes in consul 0.7.3 there is need to not use connection limit in case of long pooling