### PR TITLE
[ConsulCache] Set retry threads as deamon

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.orbitz.consul.ConsulException;
 import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.ConsulResponse;
@@ -49,7 +50,8 @@ public class ConsulCache<K, V> {
     private final AtomicReference<ImmutableMap<K, V>> lastResponse = new AtomicReference<ImmutableMap<K, V>>(ImmutableMap.<K, V>of());
     private final AtomicReference<State> state = new AtomicReference<State>(State.latent);
     private final CountDownLatch initLatch = new CountDownLatch(1);
-    private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder().setDaemon(true).build());
     private final CopyOnWriteArrayList<Listener<K, V>> listeners = new CopyOnWriteArrayList<Listener<K, V>>();
 
     private final Function<V, K> keyConversion;


### PR DESCRIPTION
Currently in caches, retry threads are user threads.
Hence, if consul fails, the retry mechanism may prevent the application to
stop.
We add a thread factory in the executor service to make the retry threads
as deamon. This would prevent this issue.
see: [Thread](https://docs.oracle.com/javase/7/docs/api/java/lang/Thread.html)

Change-Id: I0343c46493d25ed0ab33bead3f8bc9dca57fcaec