### PR TITLE
Clarify comment about having to continuously check in for TTL checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ Basic Usage
 
 ### Example 1: Register and check your service in with Consul.  
 
-Note that you need to continually check in before the TTL expires, otherwise your service's state will be marked as "critical".
-
 ```java
 Consul consul = Consul.builder().build(); // connect to Consul on localhost
 AgentClient agentClient = consul.agentClient();
@@ -72,6 +70,7 @@ String serviceId = "1";
 
 agentClient.register(8080, 3L, serviceName, serviceId); // registers with a TTL of 3 seconds
 agentClient.pass(serviceId); // check in with Consul, serviceId required only.  client will prepend "service:" for service level checks.
+// Note that you need to continually check in before the TTL expires, otherwise your service's state will be marked as "critical".
 ```
 
 ### Example 2: Find available (healthy) services.


### PR DESCRIPTION
If someone is only starting out with Consul they may think calling `pass()` once, like in the example, is enough. For example they may think the client library will ensure the Dead Man Switch is maintained. Moving the comment about the user being responsible to be next to the `pass()` call should make it more clear for new users.