### PR TITLE
Shutdownable ExecutorService

### DIFF
--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -20,6 +20,7 @@ import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -51,6 +52,7 @@ public class Consul {
     private final PreparedQueryClient preparedQueryClient;
     private final CoordinateClient coordinateClient;
     private final OperatorClient operatorClient;
+    private final ExecutorService executorService;
 
     /**
      * Private constructor.
@@ -60,7 +62,8 @@ public class Consul {
                    KeyValueClient keyValueClient, CatalogClient catalogClient,
                    StatusClient statusClient, SessionClient sessionClient,
                    EventClient eventClient, PreparedQueryClient preparedQueryClient,
-                   CoordinateClient coordinateClient, OperatorClient operatorClient) {
+                   CoordinateClient coordinateClient, OperatorClient operatorClient,
+                   ExecutorService executorService) {
         this.agentClient = agentClient;
         this.healthClient = healthClient;
         this.keyValueClient = keyValueClient;
@@ -71,9 +74,15 @@ public class Consul {
         this.preparedQueryClient = preparedQueryClient;
         this.coordinateClient = coordinateClient;
         this.operatorClient = operatorClient;
+        this.executorService = executorService;
     }
 
-
+    /**
+     * Destroys the Object internal state.
+     */
+    public void destroy() {
+        this.executorService.shutdownNow();
+    }
 
     /**
      * Get the Agent HTTP client.
@@ -466,13 +475,21 @@ public class Consul {
          */
         public Consul build() {
             final Retrofit retrofit;
+
+            /**
+             * mimics okhttp3.Dispatcher#executorService implementation, except
+             * using daemon thread so shutdown is not blocked (issue #133)
+             */
+            ExecutorService executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS,
+                    new SynchronousQueue<Runnable>(), Util.threadFactory("OkHttp Dispatcher", true));
+
             try {
                 retrofit = createRetrofit(
                         buildUrl(this.url),
                         this.sslContext,
                         this.hostnameVerifier,
                         this.proxy,
-                        Jackson.MAPPER);
+                        Jackson.MAPPER, executorService);
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }
@@ -493,7 +510,7 @@ public class Consul {
             }
             return new Consul(agentClient, healthClient, keyValueClient,
                     catalogClient, statusClient, sessionClient, eventClient,
-                    preparedQueryClient, coordinateClient, operatorClient);
+                    preparedQueryClient, coordinateClient, operatorClient, executorService);
         }
 
         private String buildUrl(URL url) {
@@ -501,7 +518,7 @@ public class Consul {
         }
 
 
-        private Retrofit createRetrofit(String url, SSLContext sslContext, HostnameVerifier hostnameVerifier, Proxy proxy, ObjectMapper mapper) throws MalformedURLException {
+        private Retrofit createRetrofit(String url, SSLContext sslContext, HostnameVerifier hostnameVerifier, Proxy proxy, ObjectMapper mapper, ExecutorService executorService) throws MalformedURLException {
             final OkHttpClient.Builder builder = new OkHttpClient.Builder();
 
             if (basicAuthInterceptor != null) {
@@ -544,12 +561,7 @@ public class Consul {
                 builder.writeTimeout(writeTimeoutMillis, TimeUnit.MILLISECONDS);
             }
 
-            /**
-             * mimics okhttp3.Dispatcher#executorService implementation, except
-             * using daemon thread so shutdown is not blocked (issue #133)
-             */
-            Dispatcher dispatcher = new Dispatcher(new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS,
-                    new SynchronousQueue<Runnable>(), Util.threadFactory("OkHttp Dispatcher", true)));
+            Dispatcher dispatcher = new Dispatcher(executorService);
             dispatcher.setMaxRequests(Integer.MAX_VALUE);
             dispatcher.setMaxRequestsPerHost(Integer.MAX_VALUE);
             builder.dispatcher(dispatcher);

--- a/src/test/java/com/orbitz/consul/LifecycleTests.java
+++ b/src/test/java/com/orbitz/consul/LifecycleTests.java
@@ -1,7 +1,18 @@
 package com.orbitz.consul;
 
 import com.google.common.net.HostAndPort;
+import okhttp3.internal.Util;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.*;
 
 public class LifecycleTests {
 
@@ -9,6 +20,61 @@ public class LifecycleTests {
     public void shouldBeDestroyable() {
         Consul client = Consul.builder().withHostAndPort(HostAndPort.fromParts("localhost", 8500)).build();
         client.destroy();
+    }
+
+    @Test
+    public void shouldDestroyTheExecutorServiceWhenDestroyMethodIsInvoked() throws InterruptedException {
+        ExecutorService executorService = mock(ExecutorService.class, new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                throw new UnsupportedOperationException("Mock Method should not be called");
+            }
+        });
+
+        doReturn(new ArrayList<>()).when(executorService).shutdownNow();
+
+        Consul client = Consul.builder().withHostAndPort(HostAndPort.fromParts("localhost", 8500)).withExecutorService(executorService).build();
+        client.destroy();
+
+        verify(executorService, times(1)).shutdownNow();
+    }
+
+    @Test
+    public void shouldBeDestroyableWithCustomExecutorService() throws InterruptedException {
+        ExecutorService executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS,
+                new SynchronousQueue<Runnable>(), Util.threadFactory("OkHttp Dispatcher", false));
+
+        executorService.execute(new Runnable() {
+            @Override
+            public void run() {
+                Thread currentThread = Thread.currentThread();
+                System.out.println("This is a Task printing a message in Thread " + currentThread);
+            }
+        });
+        Consul client = Consul.builder().withHostAndPort(HostAndPort.fromParts("localhost", 8500)).withExecutorService(executorService).build();
+        client.destroy();
+    }
+
+    public static void main(String[] args) {
+        ExecutorService executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 10, TimeUnit.SECONDS,
+                new SynchronousQueue<Runnable>(), Util.threadFactory("OkHttp Dispatcher", false));
+
+        // execute a task in order to force the creation of a Thread in the ThreadPool
+        executorService.execute(new Runnable() {
+            @Override
+            public void run() {
+                Thread currentThread = Thread.currentThread();
+                System.out.println("This is a Task printing a message in Thread " + currentThread);
+            }
+        });
+
+        Consul client = Consul.builder().withHostAndPort(HostAndPort.fromParts("localhost", 8500)).withExecutorService(executorService).build();
+
+        // do not destroy the Consul client
+        // in order to verify that the Java VM does not terminate, and waits for some time (keepAliveTime parameter of the ThreadPoolExecutor)
+        // if we call destroy() then the JVM terminates immediately
+
+        //client.destroy();
     }
 
 }

--- a/src/test/java/com/orbitz/consul/LifecycleTests.java
+++ b/src/test/java/com/orbitz/consul/LifecycleTests.java
@@ -1,0 +1,14 @@
+package com.orbitz.consul;
+
+import com.google.common.net.HostAndPort;
+import org.junit.Test;
+
+public class LifecycleTests {
+
+    @Test
+    public void shouldBeDestroyable() {
+        Consul client = Consul.builder().withHostAndPort(HostAndPort.fromParts("localhost", 8500)).build();
+        client.destroy();
+    }
+
+}


### PR DESCRIPTION
Prior to this change, an ```ExecutorService``` (a ```ThreadPoolExecutor```actually) was created internally using fixed defaults, and couldn't be shutdown nor otherwise managed.

The ```ExecutorService``` sometimes needs to be injected by the application
instead of being created internally into the framework.

Moreover, it's generally better to be able to shutdown an ```ExecutorService``` when it's no longer needed.
In order to do that without exposing it, a new lifecycle method ```Consul#destroy()``` was introduced.

This new lifecycle method is not required to be called for existing applications, since the ```ExecutorService``` - that is created internally by default - is still creating daemon Threads.

When the application is injecting the ```ExecutorService``` and keeping a reference on it, it then have the option to shutdown it without calling the newly introduced ```Consul#destroy()``` method.
