### PR TITLE
Use datacenter from QueryOptions

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -202,6 +202,7 @@ public class ConsulCache<K, V> {
                 .token(queryOptions.getToken())
                 .consistencyMode(queryOptions.getConsistencyMode())
                 .near(queryOptions.getNear())
+                .datacenter(queryOptions.getDatacenter())
                 .build();
     }
 


### PR DESCRIPTION
As CatalogOptions will be removed, use datacenter from QueryOptions.
This change also enable cross-DC Key/Value cache.

Note:
If projects use datacenter from CatalogOptions and not QueryOptions, nothing will change.
If projects use datacenter from QueryOptions and not CatalogOptions, datacenter will be considered.
If projects use datacenter from both CatalogOptions and QueryOptions, QueryOptions datacenter will be used.

Signed-off-by: Yoann Fouquet <y.fouquet@criteo.com>