### PR TITLE
Add datacenter to EventOptions query parameters

### DIFF
--- a/src/main/java/com/orbitz/consul/option/EventOptions.java
+++ b/src/main/java/com/orbitz/consul/option/EventOptions.java
@@ -25,6 +25,7 @@ public abstract class EventOptions implements ParamAdder {
         optionallyAdd(result, "node", getNodeFilter());
         optionallyAdd(result, "service", getServiceFilter());
         optionallyAdd(result, "tag", getTagFilter());
+        optionallyAdd(result, "dc", getDatacenter());
 
         return result;
     }


### PR DESCRIPTION
Currently, the Orbitz consul Event Client cannot fire events across data centers because it is missing the "dc" query parameter when it makes requests. 

This pull request simply optionallyAdds it to the toQuery method.