### PR TITLE
Fix ServiceHealthCache constructor that drops QueryOptions argument

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
@@ -72,7 +72,7 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
             final boolean passing,
             final QueryOptions queryOptions,
             final int watchSeconds) {
-        return newCache(healthClient, serviceName, passing, watchSeconds, QueryOptions.BLANK);
+        return newCache(healthClient, serviceName, passing, watchSeconds, queryOptions);
     }
 
     public static ServiceHealthCache newCache(final HealthClient healthClient, final String serviceName) {


### PR DESCRIPTION
fixes OrbitzWorldwide/consul-client#250