### PR TITLE
Upgrade Guava to 22.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ before_install:
   - unzip consul_0.7.2_linux_amd64.zip
   - ./consul agent -server -bootstrap -data-dir data &
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 script: mvn clean test
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>22.0</version>
         </dependency>
         <!-- this dependency is required to avoid javax.annotation.CheckReturnValue,
          see https://github.com/google/guava/issues/2450 for more details -->

--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -373,7 +373,7 @@ public class Consul {
          */
         public Builder withHostAndPort(HostAndPort hostAndPort) {
             try {
-                this.url = new URL("http", hostAndPort.getHostText(), hostAndPort.getPort(), "");
+                this.url = new URL("http", hostAndPort.getHost(), hostAndPort.getPort(), "");
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
`com.google.common.net.HostAndPort.getHostText` was removed in guava 22.0