### PR TITLE
Add ServiceTags in checks

### DIFF
--- a/src/main/java/com/orbitz/consul/model/agent/Check.java
+++ b/src/main/java/com/orbitz/consul/model/agent/Check.java
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import org.immutables.value.Value;
+
+import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -44,6 +47,10 @@ public abstract class Check {
 
     @JsonProperty("ServiceID")
     public abstract Optional<String> getServiceId();
+
+    @JsonProperty("ServiceTags")
+    @JsonDeserialize(as = ImmutableList.class, contentAs = String.class)
+    public abstract List<String> getServiceTags();
 
     @JsonProperty("DeregisterCriticalServiceAfter")
     public abstract Optional<String> getDeregisterCriticalServiceAfter();

--- a/src/main/java/com/orbitz/consul/model/health/HealthCheck.java
+++ b/src/main/java/com/orbitz/consul/model/health/HealthCheck.java
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import org.immutables.value.Value;
+
+import java.util.List;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableHealthCheck.class)
@@ -36,5 +39,9 @@ public abstract class HealthCheck {
 
     @JsonProperty("ServiceName")
     public abstract Optional<String> getServiceName();
+
+    @JsonProperty("ServiceTags")
+    @JsonDeserialize(as = ImmutableList.class, contentAs = String.class)
+    public abstract List<String> getServiceTags();
 
 }

--- a/src/test/java/com/orbitz/consul/model/agent/CheckTest.java
+++ b/src/test/java/com/orbitz/consul/model/agent/CheckTest.java
@@ -2,6 +2,10 @@ package com.orbitz.consul.model.agent;
 
 import org.junit.Test;
 
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
 public class CheckTest {
 
     @Test(expected = IllegalStateException.class)
@@ -32,5 +36,26 @@ public class CheckTest {
                 .script("/bin/echo \"hi\"")
                 .name("name")
                 .build();
+    }
+
+    @Test
+    public void serviceTagsAreNotNullWhenNotSpecified() {
+        Check check = ImmutableCheck.builder()
+                .name("name")
+                .id("id")
+                .build();
+
+        assertEquals(Collections.emptyList(), check.getServiceTags());
+    }
+
+    @Test
+    public void serviceTagsCanBeAddedToCheck() {
+        Check check = ImmutableCheck.builder()
+                .name("name")
+                .id("id")
+                .addServiceTags("myTag")
+                .build();
+
+        assertEquals(Collections.singletonList("myTag"), check.getServiceTags());
     }
 }

--- a/src/test/java/com/orbitz/consul/model/health/HealthCheckTest.java
+++ b/src/test/java/com/orbitz/consul/model/health/HealthCheckTest.java
@@ -1,0 +1,35 @@
+package com.orbitz.consul.model.health;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class HealthCheckTest {
+
+    @Test
+    public void serviceTagsAreNotNullWhenNotSpecified() {
+        HealthCheck check = ImmutableHealthCheck.builder()
+                .name("name")
+                .node("node")
+                .checkId("id")
+                .status("passing")
+                .build();
+
+        assertEquals(Collections.emptyList(), check.getServiceTags());
+    }
+
+    @Test
+    public void serviceTagsCanBeAddedToHealthCheck() {
+        HealthCheck check = ImmutableHealthCheck.builder()
+                .name("name")
+                .node("node")
+                .checkId("id")
+                .status("passing")
+                .addServiceTags("myTag")
+                .build();
+
+        assertEquals(Collections.singletonList("myTag"), check.getServiceTags());
+    }
+}


### PR DESCRIPTION
From consul 0.8.2, service tags are available for checks.
You can see them in agent endpoint (Check):
 - /v1/agent/checks
You can also see them in health endpoint (HealthCheck):
 - /v1/health/service/<my-service>
 - /v1/health/state/<state>
 - /v1/health/checks/<my-service>

This in documented in https://www.consul.io/api/health.html