### PR TITLE
Copy tags from additional query options

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -221,13 +221,16 @@ public class ConsulCache<K, V> {
         checkArgument(!queryOptions.getIndex().isPresent() && !queryOptions.getWait().isPresent(),
                 "Index and wait cannot be overridden");
 
-        return ImmutableQueryOptions.builder()
+        ImmutableQueryOptions.Builder builder =  ImmutableQueryOptions.builder()
                 .from(watchDefaultParams(index, blockSeconds))
                 .token(queryOptions.getToken())
                 .consistencyMode(queryOptions.getConsistencyMode())
                 .near(queryOptions.getNear())
-                .datacenter(queryOptions.getDatacenter())
-                .build();
+                .datacenter(queryOptions.getDatacenter());
+        for (String tag : queryOptions.getTag()) {
+            builder.addTag(tag);
+        }
+        return builder.build();
     }
 
     private static QueryOptions watchDefaultParams(final BigInteger index, final int blockSeconds) {

--- a/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
@@ -386,6 +386,7 @@ public class ConsulCacheTest extends BaseIntegrationTest {
         BigInteger index = new BigInteger("12");
         QueryOptions additionalOptions = ImmutableQueryOptions.builder()
                 .consistencyMode(ConsistencyMode.STALE)
+                .addTag("someTag")
                 .token("186596")
                 .near("156892")
                 .build();
@@ -394,6 +395,7 @@ public class ConsulCacheTest extends BaseIntegrationTest {
                 .index(index)
                 .wait("10s")
                 .consistencyMode(ConsistencyMode.STALE)
+                .addTag("someTag")
                 .token("186596")
                 .near("156892")
                 .build();


### PR DESCRIPTION
Tags provided in `QueryOptions` are lost at query time: they are not forwarded to the actual query.