### PR TITLE
Include Guava in shaded and relocated libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,6 @@
                                 <excludes>
                                     <exclude>org.slf4j:slf4j-api</exclude>
                                     <exclude>org.immutables:values</exclude>
-                                    <exclude>com.google.guava:guava</exclude>
                                 </excludes>
                             </artifactSet>
                             <relocations>
@@ -283,6 +282,10 @@
                                     <pattern>com.fasterxml</pattern>
                                     <shadedPattern>com.orbitz.fasterxml</shadedPattern>
                                 </relocation>
+                              <relocation>
+                                <pattern>com.google</pattern>
+                                <shadedPattern>com.orbitz.google</shadedPattern>
+                              </relocation>
                             </relocations>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Guava is a very common dependency for many libraries. Since its versions are not always aligned, it causes API conflicts (some are detected at runtime).

I noticed that you already unshaded Guava and Jackson with 227f93a754f1044dca5b937f04c6e3205d2b2d42.
I also noticed that you shaded back Jackson with b48eebaf198a913818c7c568b706768f6a9b5109. 

I am open to discussions around that (this pull-request can be a good place for it if you agree). If you have some insights on why you (un|re)shaded them, I'm interested.