### PR TITLE
Add Guava in shaded Jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,6 @@
                                 <excludes>
                                     <exclude>org.slf4j:slf4j-api</exclude>
                                     <exclude>org.immutables:values</exclude>
-                                    <exclude>com.google.guava:guava</exclude>
                                 </excludes>
                             </artifactSet>
                             <relocations>


### PR DESCRIPTION
Google packages are relocated in shading step but Guava is excluded.
It prevents from using some APIs. Eg:

```
Consul.builder()
    .withHostAndPort(HostAndPort.fromHost("foo:8080"));
```

The required `HostAndPort` is
`com.orbitz.google.commons.net.HostAndPort` but this class is not
provided.