### PR TITLE
Move to Java 8(and some refactoring)

### DIFF
--- a/src/main/java/com/orbitz/consul/AgentClient.java
+++ b/src/main/java/com/orbitz/consul/AgentClient.java
@@ -413,11 +413,7 @@ public class AgentClient {
      */
     public void check(String checkId, State state, String note) throws NotRegisteredException {
         try {
-            Map<String, String> query = Collections.emptyMap();
-
-            if (note != null) {
-                query = ImmutableMap.of("note", note);
-            }
+            Map<String, String> query = note == null ? Collections.emptyMap() : ImmutableMap.of("note", note);
 
             handle(api.check(state.getPath(), checkId, query));
         } catch (Exception ex) {
@@ -546,12 +542,8 @@ public class AgentClient {
      * @return <code>true</code> if successful, otherwise <code>false</code>.
      */
     public boolean join(String address, boolean wan) {
-        Map<String, String> query = Collections.emptyMap();
+        Map<String, String> query = wan ? ImmutableMap.of("wan", "1") : Collections.emptyMap();
         boolean result = true;
-
-        if (wan) {
-            query = ImmutableMap.of("wan", "1");
-        }
 
         try {
             handle(api.join(address, query));

--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -510,7 +510,7 @@ public class Consul {
                  * using daemon thread so shutdown is not blocked (issue #133)
                  */
                 executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS,
-                        new SynchronousQueue<Runnable>(), Util.threadFactory("OkHttp Dispatcher", true));
+                        new SynchronousQueue<>(), Util.threadFactory("OkHttp Dispatcher", true));
             }
 
             try {

--- a/src/main/java/com/orbitz/consul/CoordinateClient.java
+++ b/src/main/java/com/orbitz/consul/CoordinateClient.java
@@ -45,12 +45,7 @@ public class CoordinateClient {
     }
 
     private Map<String, String> dcQuery(String dc) {
-        Map<String, String> query = Collections.emptyMap();
-
-        if (dc != null) {
-            query = ImmutableMap.of("dc", dc);
-        }
-        return query;
+        return dc != null ? ImmutableMap.of("dc", dc) : Collections.emptyMap();
     }
 
     /**

--- a/src/main/java/com/orbitz/consul/EventClient.java
+++ b/src/main/java/com/orbitz/consul/EventClient.java
@@ -107,11 +107,7 @@ public class EventClient {
      *  a list of {@link com.orbitz.consul.model.event.Event} objects.
      */
     public EventResponse listEvents(String name, QueryOptions queryOptions) {
-        Map<String, String> query = Collections.emptyMap();
-
-        if (StringUtils.isNotEmpty(name)) {
-            query = ImmutableMap.of("name", name);
-        }
+        Map<String, String> query = StringUtils.isNotEmpty(name) ? ImmutableMap.of("name", name) : Collections.emptyMap();
 
         return response(api.listEvents(query));
     }
@@ -164,11 +160,7 @@ public class EventClient {
      * @param callback The callback to asynchronously process the result.
      */
     public void listEvents(String name, QueryOptions queryOptions, EventResponseCallback callback) {
-        Map<String, String> query = Collections.emptyMap();
-
-        if (StringUtils.isNotEmpty(name)) {
-            query = ImmutableMap.of("name", name);
-        }
+        Map<String, String> query = StringUtils.isNotEmpty(name) ? ImmutableMap.of("name", name) : Collections.emptyMap();
 
         response(api.listEvents(query), callback);
     }

--- a/src/main/java/com/orbitz/consul/KeyValueClient.java
+++ b/src/main/java/com/orbitz/consul/KeyValueClient.java
@@ -152,7 +152,7 @@ public class KeyValueClient {
             @Override
             public void onComplete(ConsulResponse<List<Value>> consulResponse) {
                 callback.onComplete(
-                        new ConsulResponse<Optional<Value>>(getSingleValue(consulResponse.getResponse()),
+                        new ConsulResponse<>(getSingleValue(consulResponse.getResponse()),
                                 consulResponse.getLastContact(),
                                 consulResponse.isKnownLeader(), consulResponse.getIndex()));
             }
@@ -214,7 +214,7 @@ public class KeyValueClient {
 
         List<Value> result = extract(api.getValue(trimLeadingSlash(key), query), NOT_FOUND_404);
 
-        return result == null ? Collections.<Value>emptyList() : result;
+        return result == null ? Collections.emptyList() : result;
     }
 
     /**
@@ -305,7 +305,7 @@ public class KeyValueClient {
      * @return A list of zero to many string values.
      */
     public List<String> getValuesAsString(String key, Charset charset) {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
 
         for(Value value : getValues(key)) {
             value.getValueAsString(charset).ifPresent(result::add);
@@ -417,7 +417,7 @@ public class KeyValueClient {
      * @return A list of zero to many keys.
      */
     public List<String> getKeys(String key) {
-        return extract(api.getKeys(trimLeadingSlash(key), ImmutableMap.<String, Object>of("keys", "true")));
+        return extract(api.getKeys(trimLeadingSlash(key), ImmutableMap.of("keys", "true")));
     }
 
     /**
@@ -540,8 +540,8 @@ public class KeyValueClient {
     public ConsulResponse<TxResponse> performTransaction(ConsistencyMode consistency, Operation... operations) {
 
         Map<String, Object> query = consistency == ConsistencyMode.DEFAULT
-                ? ImmutableMap.<String, Object>of()
-                : ImmutableMap.<String, Object>of(consistency.toParam().get(), "true");
+                ? ImmutableMap.of()
+                : ImmutableMap.of(consistency.toParam().get(), "true");
 
         try {
             return extractConsulResponse(api.performTransaction(RequestBody.create(MediaType.parse("application/json"),

--- a/src/main/java/com/orbitz/consul/KeyValueClient.java
+++ b/src/main/java/com/orbitz/consul/KeyValueClient.java
@@ -278,10 +278,7 @@ public class KeyValueClient {
      * {@link Optional#empty()}
      */
     public Optional<String> getValueAsString(String key, Charset charset) {
-        for (Value v: getValue(key).map(Collections::singleton).orElse(Collections.emptySet())) {
-            return v.getValueAsString(charset);
-        }
-        return Optional.empty();
+        return getValue(key).flatMap(v -> v.getValueAsString(charset));
     }
 
     /**
@@ -311,9 +308,7 @@ public class KeyValueClient {
         List<String> result = new ArrayList<String>();
 
         for(Value value : getValues(key)) {
-            if (value.getValueAsString(charset).isPresent()) {
-                result.add(value.getValueAsString(charset).get());
-            }
+            value.getValueAsString(charset).ifPresent(result::add);
         }
 
         return result;
@@ -499,8 +494,7 @@ public class KeyValueClient {
      * {@link Optional#empty()}
      */
     public Optional<String> getSession(String key) {
-        Optional<Value> value = getValue(key);
-        return value.isPresent() ? value.get().getSession() : Optional.empty();
+        return getValue(key).flatMap(Value::getSession);
     }
 
     /**

--- a/src/main/java/com/orbitz/consul/OperatorClient.java
+++ b/src/main/java/com/orbitz/consul/OperatorClient.java
@@ -23,7 +23,7 @@ public class OperatorClient {
     }
 
     public RaftConfiguration getRaftConfiguration() {
-        return extract(api.getConfiguration(ImmutableMap.<String, String>of()));
+        return extract(api.getConfiguration(ImmutableMap.of()));
     }
 
     public RaftConfiguration getRaftConfiguration(String datacenter) {
@@ -43,7 +43,7 @@ public class OperatorClient {
     }
 
     public void deletePeer(String address) {
-        handle(api.deletePeer(address, ImmutableMap.<String, String>of()));
+        handle(api.deletePeer(address, ImmutableMap.of()));
     }
 
     public void deletePeer(String address, String datacenter) {

--- a/src/main/java/com/orbitz/consul/PreparedQueryClient.java
+++ b/src/main/java/com/orbitz/consul/PreparedQueryClient.java
@@ -118,7 +118,7 @@ public class PreparedQueryClient {
      * @return A {@link QueryResults} object containing service instances.
      */
     public QueryResults execute(String nameOrId) {
-        return extract(api.execute(nameOrId, Collections.<String, Object>emptyMap()));
+        return extract(api.execute(nameOrId, Collections.emptyMap()));
     }
 
     /**

--- a/src/main/java/com/orbitz/consul/PreparedQueryClient.java
+++ b/src/main/java/com/orbitz/consul/PreparedQueryClient.java
@@ -58,10 +58,7 @@ public class PreparedQueryClient {
     }
 
     private Map<String, String> dcQuery(String dc) {
-        if (dc != null) {
-            return ImmutableMap.of("dc", dc);
-        }
-        return Collections.emptyMap();
+        return dc != null ? ImmutableMap.of("dc", dc): Collections.emptyMap();
     }
     
     /**

--- a/src/main/java/com/orbitz/consul/SessionClient.java
+++ b/src/main/java/com/orbitz/consul/SessionClient.java
@@ -60,12 +60,7 @@ public class SessionClient {
     }
 
     private Map<String, String> dcQuery(String dc) {
-        Map<String, String> query = Collections.emptyMap();
-
-        if (dc != null) {
-            query = ImmutableMap.of("dc", dc);
-        }
-        return query;
+        return dc != null ? ImmutableMap.of("dc", dc) : Collections.emptyMap();
     }
 
     public Optional<SessionInfo> renewSession(final String sessionId) {

--- a/src/main/java/com/orbitz/consul/SessionClient.java
+++ b/src/main/java/com/orbitz/consul/SessionClient.java
@@ -83,7 +83,7 @@ public class SessionClient {
         List<SessionInfo> sessionInfo = extract(api.renewSession(sessionId,
                 ImmutableMap.<String, String>of(), dcQuery(dc)));
 
-        return sessionInfo != null && sessionInfo.isEmpty() ? Optional.empty() :
+        return sessionInfo == null || sessionInfo.isEmpty() ? Optional.empty() :
                 Optional.of(sessionInfo.get(0));
     }
 
@@ -134,7 +134,7 @@ public class SessionClient {
     public Optional<SessionInfo> getSessionInfo(final String sessionId, final String dc) {
         List<SessionInfo> sessionInfo = extract(api.getSessionInfo(sessionId, dcQuery(dc)));
 
-        return sessionInfo != null && sessionInfo.isEmpty() ? Optional.empty() :
+        return sessionInfo == null || sessionInfo.isEmpty() ? Optional.empty() :
                 Optional.of(sessionInfo.get(0));
     }
 

--- a/src/main/java/com/orbitz/consul/SessionClient.java
+++ b/src/main/java/com/orbitz/consul/SessionClient.java
@@ -76,7 +76,7 @@ public class SessionClient {
      */
     public Optional<SessionInfo> renewSession(final String dc, final String sessionId) {
         List<SessionInfo> sessionInfo = extract(api.renewSession(sessionId,
-                ImmutableMap.<String, String>of(), dcQuery(dc)));
+                ImmutableMap.of(), dcQuery(dc)));
 
         return sessionInfo == null || sessionInfo.isEmpty() ? Optional.empty() :
                 Optional.of(sessionInfo.get(0));

--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -49,15 +49,15 @@ public class ConsulCache<K, V> {
     static final String BACKOFF_DELAY_PROPERTY = "com.orbitz.consul.cache.backOffDelay";
     private static final long BACKOFF_DELAY_QTY_IN_MS = getBackOffDelayInMs(System.getProperties());
 
-    private final AtomicReference<BigInteger> latestIndex = new AtomicReference<BigInteger>(null);
+    private final AtomicReference<BigInteger> latestIndex = new AtomicReference<>(null);
     private final AtomicLong lastContact = new AtomicLong();
     private final AtomicBoolean isKnownLeader = new AtomicBoolean();
-    private final AtomicReference<ImmutableMap<K, V>> lastResponse = new AtomicReference<ImmutableMap<K, V>>(null);
-    private final AtomicReference<State> state = new AtomicReference<State>(State.latent);
+    private final AtomicReference<ImmutableMap<K, V>> lastResponse = new AtomicReference<>(null);
+    private final AtomicReference<State> state = new AtomicReference<>(State.latent);
     private final CountDownLatch initLatch = new CountDownLatch(1);
     private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor(
             new ThreadFactoryBuilder().setDaemon(true).build());
-    private final CopyOnWriteArrayList<Listener<K, V>> listeners = new CopyOnWriteArrayList<Listener<K, V>>();
+    private final CopyOnWriteArrayList<Listener<K, V>> listeners = new CopyOnWriteArrayList<>();
     private final ReentrantLock listenersStartingLock = new ReentrantLock();
 
     private final Function<V, K> keyConversion;

--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -128,12 +128,7 @@ public class ConsulCache<K, V> {
                 }
                 LOGGER.error(String.format("Error getting response from consul. will retry in %d %s", BACKOFF_DELAY_QTY_IN_MS, TimeUnit.MILLISECONDS), throwable);
 
-                executorService.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        runCallback();
-                    }
-                }, BACKOFF_DELAY_QTY_IN_MS, TimeUnit.MILLISECONDS);
+                executorService.schedule(ConsulCache.this::runCallback, BACKOFF_DELAY_QTY_IN_MS, TimeUnit.MILLISECONDS);
             }
         };
     }

--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -150,12 +150,12 @@ public class ConsulCache<K, V> {
         return TimeUnit.SECONDS.toMillis(10);
     }
 
-    public void start() throws Exception {
+    public void start() {
         checkState(state.compareAndSet(State.latent, State.starting),"Cannot transition from state %s to %s", state.get(), State.starting);
         runCallback();
     }
 
-    public void stop() throws Exception {
+    public void stop() {
         State previous = state.getAndSet(State.stopped);
         if (previous != State.stopped) {
             executorService.shutdownNow();

--- a/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
+++ b/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
@@ -2,12 +2,8 @@ package com.orbitz.consul.cache;
 
 import com.google.common.base.Function;
 import com.orbitz.consul.HealthClient;
-import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.health.HealthCheck;
 import com.orbitz.consul.option.QueryOptions;
-
-import java.math.BigInteger;
-import java.util.List;
 
 public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
 
@@ -31,12 +27,9 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
             final QueryOptions queryOptions,
             Function<HealthCheck, String> keyExtractor) {
 
-        CallbackConsumer<HealthCheck> callbackConsumer = new CallbackConsumer<HealthCheck>() {
-            @Override
-            public void consume(BigInteger index, ConsulResponseCallback<List<HealthCheck>> callback) {
-                QueryOptions params = watchParams(index, watchSeconds, queryOptions);
-                healthClient.getChecksByState(state, params, callback);
-            }
+        CallbackConsumer<HealthCheck> callbackConsumer = (index, callback) -> {
+            QueryOptions params = watchParams(index, watchSeconds, queryOptions);
+            healthClient.getChecksByState(state, params, callback);
         };
 
         return new HealthCheckCache(keyExtractor, callbackConsumer);
@@ -48,14 +41,7 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
             final int watchSeconds,
             final QueryOptions queryOptions) {
 
-        Function<HealthCheck, String> keyExtractor = new Function<HealthCheck, String>() {
-            @Override
-            public String apply(HealthCheck input) {
-                return input.getCheckId();
-            }
-        };
-
-        return newCache(healthClient, state, watchSeconds, queryOptions, keyExtractor);
+        return newCache(healthClient, state, watchSeconds, queryOptions, HealthCheck::getCheckId);
     }
 
     public static HealthCheckCache newCache(

--- a/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
+++ b/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
@@ -27,12 +27,10 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
             final QueryOptions queryOptions,
             Function<HealthCheck, String> keyExtractor) {
 
-        CallbackConsumer<HealthCheck> callbackConsumer = (index, callback) -> {
+        return new HealthCheckCache(keyExtractor, (index, callback) -> {
             QueryOptions params = watchParams(index, watchSeconds, queryOptions);
             healthClient.getChecksByState(state, params, callback);
-        };
-
-        return new HealthCheckCache(keyExtractor, callbackConsumer);
+        });
     }
 
     public static HealthCheckCache newCache(

--- a/src/main/java/com/orbitz/consul/cache/KVCache.java
+++ b/src/main/java/com/orbitz/consul/cache/KVCache.java
@@ -40,12 +40,10 @@ public class KVCache extends ConsulCache<String, Value> {
 
         final Function<Value, String> keyExtractor = getKeyExtractorFunction(keyPath);
 
-        final CallbackConsumer<Value> callbackConsumer = (index, callback) -> {
+        return new KVCache(keyExtractor, (index, callback) -> {
             QueryOptions params = watchParams(index, watchSeconds, queryOptions);
             kvClient.getValues(keyPath, params, callback);
-        };
-
-        return new KVCache(keyExtractor, callbackConsumer);
+        });
     }
 
     @VisibleForTesting

--- a/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
+++ b/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
@@ -2,12 +2,8 @@ package com.orbitz.consul.cache;
 
 import com.google.common.base.Function;
 import com.orbitz.consul.CatalogClient;
-import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.health.Node;
 import com.orbitz.consul.option.QueryOptions;
-
-import java.math.BigInteger;
-import java.util.List;
 
 
 public class NodesCatalogCache extends ConsulCache<String, Node> {
@@ -20,21 +16,10 @@ public class NodesCatalogCache extends ConsulCache<String, Node> {
             final CatalogClient catalogClient,
             final QueryOptions queryOptions,
             final int watchSeconds) {
-        Function<Node, String> keyExtractor = new Function<Node, String>() {
-            @Override
-            public String apply(Node node) {
-                return node.getNode();
-            }
-        };
 
-        CallbackConsumer<Node> callbackConsumer = new CallbackConsumer<Node>() {
-            @Override
-            public void consume(BigInteger index, ConsulResponseCallback<List<Node>> callback) {
-                catalogClient.getNodes(watchParams(index, watchSeconds, queryOptions), callback);
-            }
-        };
+        CallbackConsumer<Node> callbackConsumer = (index, callback) -> catalogClient.getNodes(watchParams(index, watchSeconds, queryOptions), callback);
 
-        return new NodesCatalogCache(keyExtractor, callbackConsumer);
+        return new NodesCatalogCache(Node::getNode, callbackConsumer);
 
     }
 

--- a/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
+++ b/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
@@ -17,9 +17,8 @@ public class NodesCatalogCache extends ConsulCache<String, Node> {
             final QueryOptions queryOptions,
             final int watchSeconds) {
 
-        CallbackConsumer<Node> callbackConsumer = (index, callback) -> catalogClient.getNodes(watchParams(index, watchSeconds, queryOptions), callback);
-
-        return new NodesCatalogCache(Node::getNode, callbackConsumer);
+        return new NodesCatalogCache(Node::getNode, (index, callback) ->
+                catalogClient.getNodes(watchParams(index, watchSeconds, queryOptions), callback));
 
     }
 

--- a/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
@@ -30,16 +30,14 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
             final QueryOptions queryOptions,
             final Function<ServiceHealth, ServiceHealthKey> keyExtractor) {
 
-        CallbackConsumer<ServiceHealth> callbackConsumer = (index, callback) -> {
+        return new ServiceHealthCache(keyExtractor, (index, callback) -> {
             QueryOptions params = watchParams(index, watchSeconds, queryOptions);
             if (passing) {
                 healthClient.getHealthyServiceInstances(serviceName, params, callback);
             } else {
                 healthClient.getAllServiceInstances(serviceName, params, callback);
             }
-        };
-
-        return new ServiceHealthCache(keyExtractor, callbackConsumer);
+        });
     }
 
     public static ServiceHealthCache newCache(

--- a/src/main/java/com/orbitz/consul/model/kv/Value.java
+++ b/src/main/java/com/orbitz/consul/model/kv/Value.java
@@ -48,14 +48,6 @@ public abstract class Value {
     @JsonIgnore
     @org.immutables.value.Value.Lazy
     public Optional<String> getValueAsString(Charset charset) {
-
-        if (getValue().isPresent()) {
-            return Optional.of(
-                    new String(BaseEncoding.base64().decode(getValue().get()), charset)
-            );
-        } else {
-            return Optional.empty();
-        }
-
+        return getValue().map(s -> new String(BaseEncoding.base64().decode(s), charset));
     }
 }

--- a/src/main/java/com/orbitz/consul/option/Options.java
+++ b/src/main/java/com/orbitz/consul/option/Options.java
@@ -8,10 +8,8 @@ import java.util.Map;
 public class Options {
     private Options(){};
 
-    static void optionallyAdd(Map<String, Object> data, String key, Optional val) {
-        if (val.isPresent()) {
-            data.put(key, val.get().toString());
-        }
+    static void optionallyAdd(Map<String, Object> data, String key, @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<?> val) {
+        val.ifPresent(value -> data.put(key, value.toString()));
     }
 
     public static Map<String, Object> from(ParamAdder... options) {

--- a/src/main/java/com/orbitz/consul/option/Options.java
+++ b/src/main/java/com/orbitz/consul/option/Options.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class Options {
-    private Options(){};
+    private Options(){}
 
     static void optionallyAdd(Map<String, Object> data, String key, @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<?> val) {
         val.ifPresent(value -> data.put(key, value.toString()));

--- a/src/main/java/com/orbitz/consul/option/QueryOptions.java
+++ b/src/main/java/com/orbitz/consul/option/QueryOptions.java
@@ -47,14 +47,14 @@ public abstract class QueryOptions implements ParamAdder {
     @Value.Derived
     public List<String> getNodeMetaQuery() {
         return getNodeMeta() == null
-                ? Collections.<String>emptyList()
+                ? Collections.emptyList()
                 : ImmutableList.copyOf(getNodeMeta());
     }
 
     @Value.Derived
     public List<String> getTagsQuery() {
         return getTag() == null
-                ? Collections.<String>emptyList()
+                ? Collections.emptyList()
                 : ImmutableList.copyOf(getTag());
     }
 

--- a/src/main/java/com/orbitz/consul/option/TransactionOptions.java
+++ b/src/main/java/com/orbitz/consul/option/TransactionOptions.java
@@ -28,9 +28,7 @@ public abstract class TransactionOptions implements ParamAdder {
         Map<String, Object> result = new HashMap<>();
 
         Optional<String> consistencyMode = getConsistencyMode().toParam();
-        if (consistencyMode.isPresent()) {
-            result.put(consistencyMode.get(), "true");
-        }
+        consistencyMode.ifPresent(s -> result.put(s, "true"));
 
         optionallyAdd(result, "dc", getDatacenter());
 

--- a/src/main/java/com/orbitz/consul/util/Base64EncodingSerializer.java
+++ b/src/main/java/com/orbitz/consul/util/Base64EncodingSerializer.java
@@ -1,18 +1,17 @@
 package com.orbitz.consul.util;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import java.util.Optional;
 import com.google.common.io.BaseEncoding;
 
 import java.io.IOException;
+import java.util.Optional;
 
 public class Base64EncodingSerializer extends JsonSerializer<Optional<String>> {
 
     @Override
-    public void serialize(Optional<String> string, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
+    public void serialize(Optional<String> string, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
         if (string.isPresent()) {
             jsonGenerator.writeString(BaseEncoding.base64().encode(string.get().getBytes()));
         } else {

--- a/src/main/java/com/orbitz/consul/util/Http.java
+++ b/src/main/java/com/orbitz/consul/util/Http.java
@@ -110,8 +110,6 @@ public class Http {
         long lastContact = lastContactHeaderValue == null ? 0 : Long.valueOf(lastContactHeaderValue);
         boolean knownLeader = knownLeaderHeaderValue == null ? false : Boolean.valueOf(knownLeaderHeaderValue);
 
-        ConsulResponse<T> consulResponse = new ConsulResponse<>(response.body(), lastContact, knownLeader, index);
-
-        return consulResponse;
+        return new ConsulResponse<>(response.body(), lastContact, knownLeader, index);
     }
 }

--- a/src/main/java/com/orbitz/consul/util/LeaderElectionUtil.java
+++ b/src/main/java/com/orbitz/consul/util/LeaderElectionUtil.java
@@ -18,12 +18,12 @@ public class LeaderElectionUtil {
     public Optional<String> getLeaderInfoForService(final String serviceName) {
         String key = getServiceKey(serviceName);
         Optional<Value> value = client.keyValueClient().getValue(key);
-        if(value.isPresent()){
-            if(value.get().getSession().isPresent()) {
-                return value.get().getValueAsString();
+        return value.flatMap(val -> {
+            if(val.getSession().isPresent()) {
+                return val.getValueAsString();
             }
-        }
-        return Optional.empty();
+            return Optional.empty();
+        });
     }
 
     public Optional<String> electNewLeaderForService(final String serviceName, final String info) {

--- a/src/main/java/com/orbitz/consul/util/SecondsDeserializer.java
+++ b/src/main/java/com/orbitz/consul/util/SecondsDeserializer.java
@@ -1,7 +1,6 @@
 package com.orbitz.consul.util;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import org.apache.commons.lang3.StringUtils;
@@ -14,7 +13,7 @@ import java.io.IOException;
 public class SecondsDeserializer extends JsonDeserializer<Long> {
 
     @Override
-    public Long deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    public Long deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         String value = p.getValueAsString();
 
         if (StringUtils.isNotEmpty(value)) {

--- a/src/main/java/com/orbitz/consul/util/UnsignedLongDeserializer.java
+++ b/src/main/java/com/orbitz/consul/util/UnsignedLongDeserializer.java
@@ -1,7 +1,6 @@
 package com.orbitz.consul.util;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.google.common.primitives.UnsignedLongs;
@@ -14,7 +13,7 @@ import java.io.IOException;
  */
 public class UnsignedLongDeserializer extends JsonDeserializer<Long> {
     @Override
-    public Long deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    public Long deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
         String sValue = jp.getValueAsString();
         return UnsignedLongs.decode(sValue);
     }


### PR DESCRIPTION
* Use lambdas/method references instead of anonymous classes
* Remove needless generics
* Use more appropriate API for Optional
* Remove unnecessary exceptions
* Replace construction
 ```java
Object o = empty();
if(notEmpty) {
    o = notEmpty();
}
return o;
``` 
by
 ```java
 return notEmpty ? notEmpty() : empty()
```