### PR TITLE
Use typesafe to enhance cache configuration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,11 @@
             <version>1.9</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+            <version>1.3.2</version>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>
@@ -256,6 +260,11 @@
                         <configuration>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>shaded</shadedClassifierName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>reference.conf</resource>
+                                </transformer>
+                            </transformers>
                             <artifactSet>
                                 <excludes>
                                     <exclude>org.slf4j:slf4j-api</exclude>
@@ -290,6 +299,10 @@
                                 <relocation>
                                     <pattern>com.google</pattern>
                                     <shadedPattern>com.orbitz.google</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.typesafe</pattern>
+                                    <shadedPattern>com.orbitz.typesafe</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/src/main/java/com/orbitz/consul/cache/CacheConfig.java
+++ b/src/main/java/com/orbitz/consul/cache/CacheConfig.java
@@ -1,0 +1,49 @@
+package com.orbitz.consul.cache;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Suppliers;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import java.util.function.Supplier;
+
+class CacheConfig {
+
+    @VisibleForTesting
+    static String CONFIG_CACHE_PATH = "com.orbitz.consul.cache";
+    @VisibleForTesting
+    static String BACKOFF_DELAY = "backOffDelay";
+
+    private static final Supplier<CacheConfig> INSTANCE = Suppliers.memoize(CacheConfig::new);
+
+    private final Config config;
+
+    private CacheConfig() {
+         this(ConfigFactory.load());
+    }
+
+    @VisibleForTesting
+    CacheConfig(Config config) {
+        this.config = config.getConfig(CONFIG_CACHE_PATH);
+    }
+
+    /**
+     * Gets the instance of the cache configuration
+     */
+    static CacheConfig get() {
+        return INSTANCE.get();
+    }
+
+    /**
+     * Gets the back-off delay used in caches.
+     * @return back-off delay in milliseconds
+     * @throws RuntimeException if an error occurs while retrieving the configuration property.
+     */
+    long getBackOffDelayInMs() {
+        try {
+            return config.getLong(BACKOFF_DELAY);
+        } catch (Exception ex) {
+            throw new RuntimeException(String.format("Error extracting config variable %s", BACKOFF_DELAY), ex);
+        }
+    }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,3 @@
+com.orbitz.consul {
+  cache.backOffDelay: 10000 //In ms
+}

--- a/src/test/java/com/orbitz/consul/cache/CacheConfigTest.java
+++ b/src/test/java/com/orbitz/consul/cache/CacheConfigTest.java
@@ -1,0 +1,27 @@
+package com.orbitz.consul.cache;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Properties;
+
+public class CacheConfigTest {
+
+    @Test
+    public void testDefaultBackOffDelay() {
+        Assert.assertEquals(10000L, CacheConfig.get().getBackOffDelayInMs());
+    }
+
+    @Test
+    public void testBackOffDelayFromProperties() {
+        String property = String.format("%s.%s", CacheConfig.CONFIG_CACHE_PATH, CacheConfig.BACKOFF_DELAY);
+        Properties properties = new Properties();
+        properties.setProperty(property, "500");
+
+        Config config = ConfigFactory.parseProperties(properties);
+        CacheConfig cacheConfig = new CacheConfig(config);
+        Assert.assertEquals(500L, cacheConfig.getBackOffDelayInMs());
+    }
+}

--- a/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
@@ -413,24 +413,4 @@ public class ConsulCacheTest extends BaseIntegrationTest {
                 .build();
         ConsulCache.watchParams(index, 10, additionalOptions);
     }
-
-    @Test
-    public void testDefaultBackOffDelay() {
-        Properties properties = new Properties();
-        Assert.assertEquals(10000L, ConsulCache.getBackOffDelayInMs(properties));
-    }
-
-    @Test
-    public void testBackOffDelayFromProperties() {
-        Properties properties = new Properties();
-        properties.setProperty(ConsulCache.BACKOFF_DELAY_PROPERTY, "500");
-        Assert.assertEquals(500L, ConsulCache.getBackOffDelayInMs(properties));
-    }
-
-    @Test
-    public void testBackOffDelayDoesNotThrow() {
-        Properties properties = new Properties();
-        properties.setProperty(ConsulCache.BACKOFF_DELAY_PROPERTY, "unparseableLong");
-        Assert.assertEquals(10000L, ConsulCache.getBackOffDelayInMs(properties));
-    }
 }


### PR DESCRIPTION
Cache uses system properties for configuration.
Typesafe would allow easy configuration of the library while keeping possible overload by system properties (to ensure compatibility).

Here, we set backOffDelay in configuration file instead of properties.