### PR TITLE
[pom] Set Java and Thirdparty dependencies version in properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
         <junitparams.version>1.0.5</junitparams.version>
         <mockito.version>1.10.19</mockito.version>
         <retrofit.version>2.3.0</retrofit.version>
-        <refrofit.jackson.version>2.0.2</refrofit.jackson.version>
         <slf4j.version>1.7.21</slf4j.version>
         <typesafe.version>1.3.2</typesafe.version>
     </properties>
@@ -86,7 +85,7 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>${refrofit.jackson.version}</version>
+            <version>${retrofit.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,21 @@
     </developers>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>8</java.version>
+
+        <apache.commons.version>3.4</apache.commons.version>
+        <commonscodec.version>1.9</commonscodec.version>
+        <findbugs.version>1.3.9</findbugs.version>
+        <guava.version>22.0</guava.version>
+        <immutables.version>2.1.19</immutables.version>
+        <jackson.version>2.7.4</jackson.version>
+        <junit.version>4.12</junit.version>
+        <junitparams.version>1.0.5</junitparams.version>
+        <mockito.version>1.10.19</mockito.version>
+        <retrofit.version>2.3.0</retrofit.version>
+        <refrofit.jackson.version>2.0.2</refrofit.jackson.version>
+        <slf4j.version>1.7.21</slf4j.version>
+        <typesafe.version>1.3.2</typesafe.version>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -66,94 +81,94 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>2.3.0</version>
+            <version>${retrofit.version}</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>2.0.2</version>
+            <version>${refrofit.jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>22.0</version>
+            <version>${guava.version}</version>
         </dependency>
         <!-- this dependency is required to avoid javax.annotation.CheckReturnValue,
          see https://github.com/google/guava/issues/2450 for more details -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>1.3.9</version>
+            <version>${findbugs.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.7.4</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.7.4</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.4</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.7.4</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-guava</artifactId>
-            <version>2.7.4</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>${apache.commons.version}</version>
         </dependency>
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
-            <version>2.1.19</version>
+            <version>${immutables.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.21</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>pl.pragmatists</groupId>
             <artifactId>JUnitParams</artifactId>
-            <version>1.0.5</version>
+            <version>${junitparams.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.9</version>
+            <version>${commonscodec.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
-            <version>1.3.2</version>
+            <version>${typesafe.version}</version>
         </dependency>
     </dependencies>
     <profiles>
@@ -226,8 +241,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This enhance readability of the pom dependencies versions and reduce risk of using several versions of related dependencies. For instance, all jackson artifacts have same version.