### PR TITLE
Convert backoff delay duration from int to string

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/CacheConfig.java
+++ b/src/main/java/com/orbitz/consul/cache/CacheConfig.java
@@ -5,6 +5,7 @@ import com.google.common.base.Suppliers;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import java.time.Duration;
 import java.util.function.Supplier;
 
 class CacheConfig {
@@ -36,12 +37,12 @@ class CacheConfig {
 
     /**
      * Gets the back-off delay used in caches.
-     * @return back-off delay in milliseconds
+     * @return back-off delay
      * @throws RuntimeException if an error occurs while retrieving the configuration property.
      */
-    long getBackOffDelayInMs() {
+    Duration getBackOffDelay() {
         try {
-            return config.getLong(BACKOFF_DELAY);
+            return config.getDuration(BACKOFF_DELAY);
         } catch (Exception ex) {
             throw new RuntimeException(String.format("Error extracting config variable %s", BACKOFF_DELAY), ex);
         }

--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -120,9 +120,9 @@ public class ConsulCache<K, V> {
                 if (!isRunning()) {
                     return;
                 }
-                LOGGER.error(String.format("Error getting response from consul. will retry in %d %s", CacheConfig.get().getBackOffDelayInMs(), TimeUnit.MILLISECONDS), throwable);
+                LOGGER.error(String.format("Error getting response from consul. will retry in %d %s", CacheConfig.get().getBackOffDelay().toMillis(), TimeUnit.MILLISECONDS), throwable);
 
-                executorService.schedule(ConsulCache.this::runCallback, CacheConfig.get().getBackOffDelayInMs(), TimeUnit.MILLISECONDS);
+                executorService.schedule(ConsulCache.this::runCallback, CacheConfig.get().getBackOffDelay().toMillis(), TimeUnit.MILLISECONDS);
             }
         };
     }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,3 +1,3 @@
 com.orbitz.consul {
-  cache.backOffDelay: 10000 //In ms
+  cache.backOffDelay: 10 seconds
 }

--- a/src/test/java/com/orbitz/consul/cache/CacheConfigTest.java
+++ b/src/test/java/com/orbitz/consul/cache/CacheConfigTest.java
@@ -11,7 +11,7 @@ public class CacheConfigTest {
 
     @Test
     public void testDefaultBackOffDelay() {
-        Assert.assertEquals(10000L, CacheConfig.get().getBackOffDelayInMs());
+        Assert.assertEquals(10000L, CacheConfig.get().getBackOffDelay().toMillis());
     }
 
     @Test
@@ -22,6 +22,6 @@ public class CacheConfigTest {
 
         Config config = ConfigFactory.parseProperties(properties);
         CacheConfig cacheConfig = new CacheConfig(config);
-        Assert.assertEquals(500L, cacheConfig.getBackOffDelayInMs());
+        Assert.assertEquals(500L, cacheConfig.getBackOffDelay().toMillis());
     }
 }


### PR DESCRIPTION
It is not a good practice to have the duration unit in the method name, comments, ...
Use java Duration instead.
Use typesafe getDuration() to convert string into Duration.

Note that if no unit is specified, the default unit is "milliseconds".
This ensures that current usage of backOffDelay are not broken.
