### PR TITLE
Set default watch duration for caches in configuration

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
+++ b/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
@@ -1,5 +1,6 @@
 package com.orbitz.consul.cache;
 
+import com.google.common.primitives.Ints;
 import com.orbitz.consul.HealthClient;
 import com.orbitz.consul.model.health.HealthCheck;
 import com.orbitz.consul.option.QueryOptions;
@@ -51,7 +52,7 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
     }
 
     public static HealthCheckCache newCache(final HealthClient healthClient, final com.orbitz.consul.model.State state) {
-        return newCache(healthClient, state, 10);
+        return newCache(healthClient, state, Ints.checkedCast(CacheConfig.get().getWatchDuration().getSeconds()));
     }
 
 }

--- a/src/main/java/com/orbitz/consul/cache/KVCache.java
+++ b/src/main/java/com/orbitz/consul/cache/KVCache.java
@@ -2,6 +2,7 @@ package com.orbitz.consul.cache;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.primitives.Ints;
 import com.orbitz.consul.KeyValueClient;
 import com.orbitz.consul.model.kv.Value;
 import com.orbitz.consul.option.QueryOptions;
@@ -80,6 +81,6 @@ public class KVCache extends ConsulCache<String, Value> {
     public static KVCache newCache(
             final KeyValueClient kvClient,
             final String rootPath) {
-        return newCache(kvClient, rootPath, 10);
+        return newCache(kvClient, rootPath, Ints.checkedCast(CacheConfig.get().getWatchDuration().getSeconds()));
     }
 }

--- a/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
+++ b/src/main/java/com/orbitz/consul/cache/NodesCatalogCache.java
@@ -1,11 +1,11 @@
 package com.orbitz.consul.cache;
 
+import com.google.common.primitives.Ints;
 import com.orbitz.consul.CatalogClient;
 import com.orbitz.consul.model.health.Node;
 import com.orbitz.consul.option.QueryOptions;
 
 import java.util.function.Function;
-
 
 public class NodesCatalogCache extends ConsulCache<String, Node> {
 
@@ -24,7 +24,8 @@ public class NodesCatalogCache extends ConsulCache<String, Node> {
     }
 
     public static NodesCatalogCache newCache(final CatalogClient catalogClient) {
-        return newCache(catalogClient, QueryOptions.BLANK, 10);
+        return newCache(catalogClient, QueryOptions.BLANK,
+                Ints.checkedCast(CacheConfig.get().getWatchDuration().getSeconds()));
     }
 
 }

--- a/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ServiceHealthCache.java
@@ -1,6 +1,7 @@
 package com.orbitz.consul.cache;
 
 import com.google.common.net.HostAndPort;
+import com.google.common.primitives.Ints;
 import com.orbitz.consul.HealthClient;
 import com.orbitz.consul.model.health.ServiceHealth;
 import com.orbitz.consul.option.QueryOptions;
@@ -41,7 +42,6 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
         });
     }
 
-
     public static ServiceHealthCache newCache(
             final HealthClient healthClient,
             final String serviceName,
@@ -62,6 +62,7 @@ public class ServiceHealthCache extends ConsulCache<ServiceHealthKey, ServiceHea
     }
 
     public static ServiceHealthCache newCache(final HealthClient healthClient, final String serviceName) {
-        return newCache(healthClient, serviceName, true, QueryOptions.BLANK, 10);
+        return newCache(healthClient, serviceName, true, QueryOptions.BLANK,
+                Ints.checkedCast(CacheConfig.get().getWatchDuration().getSeconds()));
     }
 }

--- a/src/main/resources/defaults.conf
+++ b/src/main/resources/defaults.conf
@@ -1,0 +1,3 @@
+com.orbitz.consul {
+  cache.watch: 10 seconds
+}

--- a/src/test/java/com/orbitz/consul/cache/CacheConfigTest.java
+++ b/src/test/java/com/orbitz/consul/cache/CacheConfigTest.java
@@ -5,13 +5,16 @@ import com.typesafe.config.ConfigFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
 
 public class CacheConfigTest {
 
     @Test
     public void testDefaultBackOffDelay() {
-        Assert.assertEquals(10000L, CacheConfig.get().getBackOffDelay().toMillis());
+        assertEquals(10000L, CacheConfig.get().getBackOffDelay().toMillis());
     }
 
     @Test
@@ -22,6 +25,42 @@ public class CacheConfigTest {
 
         Config config = ConfigFactory.parseProperties(properties);
         CacheConfig cacheConfig = new CacheConfig(config);
-        Assert.assertEquals(500L, cacheConfig.getBackOffDelay().toMillis());
+        assertEquals(500L, cacheConfig.getBackOffDelay().toMillis());
+    }
+
+    @Test
+    public void testDefaultWatchDuration() {
+        assertEquals(10000L, CacheConfig.get().getWatchDuration().toMillis());
+    }
+
+    @Test
+    public void testMaxWatchDuration() {
+        assertEquals(Duration.ofMinutes(10), getWatchDuration("10 minutes"));
+    }
+
+    @Test
+    public void testMinWatchDuration() {
+        assertEquals(Duration.ofSeconds(0), getWatchDuration("0 second"));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testNegativeWatchDuration() {
+        getWatchDuration("-1 second");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testTooLongWatchDuration() {
+        getWatchDuration("11 minutes");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testInvalidWatchDuration() {
+        getWatchDuration("invalid duration in second");
+    }
+
+    private Duration getWatchDuration(String duration) {
+        String config = String.format("%s.%s: %s", CacheConfig.CONFIG_CACHE_PATH, CacheConfig.WATCH_DURATION, duration);
+        CacheConfig cacheConfig = new CacheConfig(ConfigFactory.parseString(config));
+        return cacheConfig.getWatchDuration();
     }
 }


### PR DESCRIPTION
The default value of 10 seconds is set 4 times in caches.
Set its value (once) in the default configuration file.