### PR TITLE
Add request rate limiter in caches

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/CacheConfig.java
+++ b/src/main/java/com/orbitz/consul/cache/CacheConfig.java
@@ -19,6 +19,7 @@ class CacheConfig {
 
     private static String TIMEOUT_AUTO_ENABLED = "timeout.autoAdjustment.enable";
     private static String TIMEOUT_AUTO_MARGIN = "timeout.autoAdjustment.margin";
+    private static String REQUEST_RATE_LIMITER = "minTimeBetweenRequests";
 
     private static final Supplier<CacheConfig> INSTANCE = Suppliers.memoize(CacheConfig::new);
 
@@ -98,5 +99,17 @@ class CacheConfig {
         }
 
         return duration;
+    }
+
+    /**
+     * Gets the minimum time between two requests for caches.
+     * @throws RuntimeException if an error occurs while retrieving the configuration property.
+     */
+    Duration getMinimumDurationBetweenRequests() {
+        try {
+            return config.getDuration(REQUEST_RATE_LIMITER);
+        } catch (Exception ex) {
+            throw new RuntimeException(String.format("Error extracting config variable %s", REQUEST_RATE_LIMITER), ex);
+        }
     }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,7 +1,10 @@
 com.orbitz.consul {
-  cache.backOffDelay: 10 seconds
-  cache.timeout.autoAdjustment {
-    enable: true
-    margin: 2 seconds
+  cache {
+    backOffDelay: 10 seconds
+    minTimeBetweenRequests: 0 seconds
+    timeout.autoAdjustment {
+      enable: true
+      margin: 2 seconds
+    }
   }
 }


### PR DESCRIPTION
Set a minimum duration between two requests in caches.
By default, the duration is set to 0 (i.e. the feature is disabled).

In our datacenters, we sometimes have peaks of notifications. Hence, we send many requests (using cache) during the same second, which we consider useless.
Having a rate limiter, we could stop sending so many requests, and limit to 1 request per second, or 1 request per 10 seconds, ...
